### PR TITLE
chore: split log targets by source and level, include started and shutdown log events, add log file rotation.

### DIFF
--- a/SharpFM.App/Program.cs
+++ b/SharpFM.App/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using NLog;
 using System;
 
 namespace SharpFM.App;
@@ -11,7 +12,16 @@ class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        var logger = LogManager
+            .Setup()
+            .LoadConfigurationFromFile("nlog.config")
+            .GetCurrentClassLogger();
+
+        logger.Info("SharpFM has started up.");
+
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+        logger.Info("SharpFM has shut down.");
     }
 
     // Avalonia configuration, don't remove; also used by visual designer.

--- a/SharpFM.App/nlog.config
+++ b/SharpFM.App/nlog.config
@@ -23,12 +23,25 @@
 
         <!-- write logs to file in app data folder -->
         <target xsi:type="File" name="logfile"
-            fileName="${specialfolder:folder=ApplicationData}\SharpFM.log"
+            fileName="${specialfolder:folder=ApplicationData}\SharpFM\Application.log"
+            archiveFileName="${specialfolder:folder=ApplicationData}\SharpFM\Application-${date:format=yyyy-MM-dd}#{##}.log"
+            archiveEvery="Day"
+            concurrentWrites="true"
+            archiveNumbering="Rolling"
+            maxArchiveFiles="30"
             layout="${longdate}|${uppercase:${level:padding=5}}|${mdlc:item=ScopeName}|${ndlctiming:currentScope=true}|${logger}|${message} ${exception:format=tostring:innerFormat=tostring:maxInnerExceptionLevel=2}" />
     </targets>
 
     <!-- rules to map from logger name to target -->
     <rules>
-        <logger name="*" minlevel="Trace" writeTo="logfile,logconsole" />
+        <!-- write all logs to console -->
+        <logger name="*" minlevel="Trace" writeTo="logconsole" />
+
+        <!-- blackhole Avalonia Trace, Debug, and Info. only allow Warning, Error, Fatal to fall
+        through to logfile. -->
+        <logger name="Avalonia.*" minlevel="Trace" maxlevel="Info" final="true" />
+
+        <!-- anything remaining here is logged to the logfile that rotates every 30 days. -->
+        <logger name="*" minlevel="Info" writeTo="logfile" />
     </rules>
 </nlog>


### PR DESCRIPTION
- Write all logs to console target
- Write Info logs to logfile target except:
  - Avalonia.* only log Warning and above.
- Move log folder to AppData\SharpFM\Application.log.
- Rotate logs every 30 days.