### PR TITLE
chore: fix actions permission

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   release:
     name: Release
+    permissions:
+      contents: read
+      releases: write
     strategy:
       matrix:
         kind: ['linux', 'windows', 'macOS']


### PR DESCRIPTION
Potential fix for [https://github.com/fuzzzerd/SharpFM/security/code-scanning/2](https://github.com/fuzzzerd/SharpFM/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the `release` job. This should specify the least set of privileges needed. For this workflow, the main requirements are:
- Read access to repository contents (to check out/build).
- Write access to releases, since the workflow uploads release assets via `softprops/action-gh-release@v2`.

Add the following block as a child of the `release` job, above or below `runs-on` (but before `steps`):

```yaml
permissions:
  contents: read
  releases: write
```

No changes to imports or methods are necessary; just add the specified block to the job configuration in `.github/workflows/release-artifacts.yml`, preferably before the `runs-on` key to match conventions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
