### PR TITLE
chore: fix actions permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI Builds
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/fuzzzerd/SharpFM/security/code-scanning/1](https://github.com/fuzzzerd/SharpFM/security/code-scanning/1)

To fix the workflow so it adheres to least privilege principles, you should add a `permissions` block to either the root of the workflow (to apply to all jobs), or directly under the `release` job (to apply only to that job). Since there is only one job in this workflow and no step requires special permissions, the best fix is to add `permissions: contents: read` just below the workflow name near the top of the file. This will restrict GITHUB_TOKEN for all steps, preventing accidental privilege escalation and aligning with GitHub recommended practices. No other lines need to change, and no imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
