### PR TITLE
docs: update README and bump to v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,100 @@
 # SharpFM
 
-SharpFM is a cross-platform (Mac, Windows, Linux) FileMaker Pro Developer Utility to help when migrating FileMaker code between FileMaker files, sharing FileMaker code with other developers, or simply see what's happening under the hood. This means you can copy scripts, layouts, tables, etc (anything you can copy/paste in FileMaker) across machine barriers like Remote Desktop, Citrix/XenApp or anything that can copy plain text between machines, save them for later, change them if you want, then finally re-paste them into the same or other FileMaker file.
+SharpFM is a cross-platform (Mac, Windows, Linux) FileMaker Pro Developer Utility for migrating FileMaker code between files, sharing code with other developers, or inspecting what's happening under the hood. Copy scripts, layouts, tables, and fields from FileMaker Pro, edit them in structured editors, and paste them back -- across machine barriers like Remote Desktop, Citrix, or anything that supports plain text.
 
 ## Getting Started
 
-Note: SharpFM and FileMaker must be running on the same computer. In order to share or move a clip across machine barriers, you must share the text based XML version.
+Head over to [Releases](https://github.com/fuzzzerd/SharpFM/releases) and grab the latest version for your platform (Windows, Mac, Linux).
 
-- Head over to [Releases](https://github.com/fuzzzerd/SharpFM/releases), grab the latest version (binaries for Windows, Mac, Linux are all available there).
+SharpFM and FileMaker must be running on the same computer. To share clips across machines, use the XML files directly.
 
 ### Importing Clips from FileMaker
 
-- Open SharpFM.
-- Switch over to FileMaker.
-- Copy something to the clipboard (scripts, tables, layouts, etc).
-- Switch back to SharpFM.
-- Use **File > New > From Clipboard** (`Ctrl+V`) to import the clip.
-- The clip appears in the left panel with the appropriate editor on the right.
+1. Open SharpFM and FileMaker side by side.
+2. In FileMaker, copy something to the clipboard (scripts, tables, layouts, etc).
+3. In SharpFM, use **Edit > Paste from FileMaker** (`Ctrl+V`).
+4. The clip appears in the left panel with the appropriate editor on the right.
 
 ### Exporting Clips to FileMaker
 
-- Select a clip in the left panel.
-- Use **File > Save > Selected clip to Clipboard** (`Ctrl+Shift+C`).
-- Switch to FileMaker and open the appropriate destination (Database Manager, Script Workspace, Layout mode, etc).
-- Paste as you normally would.
+1. Select a clip in the left panel.
+2. Use **Edit > Copy to FileMaker** (`Ctrl+Shift+C`).
+3. Switch to FileMaker and open the appropriate destination (Database Manager, Script Workspace, Layout mode, etc).
+4. Paste as you normally would.
+
+### Creating New Clips
+
+- **File > New Script** (`Ctrl+N`) -- creates an empty script clip with the FmScript editor.
+- **File > New Table** (`Ctrl+Shift+N`) -- creates an empty table clip with the DataGrid editor.
 
 ### Editing Scripts
 
-- Select a script clip or create one with **File > New > Script** (`Ctrl+N`).
-- The script editor shows a plain-text representation of the script steps with FmScript syntax highlighting.
-- Edit the script text directly; changes are synced back to the underlying XML.
+Select a script clip to open the plain-text script editor with FmScript syntax highlighting, autocomplete, bracket matching, and validation diagnostics. Edit the script text directly -- changes sync to the underlying XML automatically.
 
 ### Editing Tables
 
-- Select a table clip or create one with **File > New > Table** (`Ctrl+Shift+N`).
-- The table editor shows a DataGrid with columns for Field Name, Type, Kind, Required, Unique, and Comment.
-- Click **+ Add Field** to add a new field, then edit its properties inline.
-- Select a field and click **Remove** or press `Delete` to remove it.
-- Change a field's Kind to Calculated or Summary, then click **Edit Calculation...** to open the calculation editor.
+Select a table clip to open the DataGrid editor with columns for Field Name, Type, Kind, Required, Unique, and Comment. Use **+ Add Field** to add fields, **Remove** or `Delete` to remove them. Change a field's Kind to Calculated or Summary, then click **Edit Calculation...** for the calculation editor.
 
 ### Viewing Raw XML
 
-- Select any clip and use **View > Show XML** (`Ctrl+Shift+X`) to open the raw XML in a separate window.
-- Edits made in the XML window are synced back to the clip when the window is closed.
+Use the **XML Viewer** plugin (`Ctrl+Shift+X`) to open a live XML panel alongside any structured editor. Edits in either direction sync automatically -- change the script and the XML updates, edit the XML and the script rebuilds.
 
-### Saving and Sharing Clips
+### Saving and Loading Clips
 
-SharpFM persists clips between sessions as XML files in a local folder.
+SharpFM persists clips as XML files in a local folder.
 
-- Use **File > Save > Save All To Folder** (`Ctrl+S`) to save all clips.
-- Use **File > Open Folder** to load clips from a different folder.
-- The clip files are plain XML and can be shared via git, email, or any text-based tool.
+- **File > Save All** (`Ctrl+S`) -- saves all clips to the current folder.
+- **File > Open Folder...** -- load clips from a different folder.
+- Clip files are plain XML and can be shared via git, email, or any text-based tool.
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+N` | New Script |
+| `Ctrl+Shift+N` | New Table |
+| `Ctrl+V` | Paste from FileMaker |
+| `Ctrl+Shift+C` | Copy to FileMaker |
+| `Ctrl+S` | Save All |
+| `Ctrl+Shift+X` | Toggle XML Viewer |
+
+## Menu Reference
+
+| Menu | Items |
+|------|-------|
+| **File** | New Script, New Table, Open Folder..., Save All, Exit |
+| **Edit** | Paste from FileMaker, Copy to FileMaker, Copy as C# Class |
+| **Plugins** | Loaded plugins (toggle panels), Manage Plugins... |
 
 ## Features
 
-- [x] Copy FileMaker Scripts, Tables, or Layouts From FileMaker Pro to their XML representation and back into FileMaker.
-- [x] Store FileMaker Scripts, Tables, and Layouts to xml files that can be shared via git, email or other text based tools.
-- [x] Edit raw FileMaker XML code (scripts, layouts, tables) with ability to paste changes back into FileMaker.
-- [x] Use AvaloniaEdit for XML editing with XML syntax highlighting.
-- [x] Plain-text script editor with FmScript syntax highlighting.
-- [x] DataGrid table/field editor with inline editing, calculation editor, and type/kind selection.
-- [x] View and edit raw XML alongside structured editors.
+- Copy FileMaker Scripts, Tables, Fields, and Layouts to their XML representation and back.
+- Persist clips as XML files shareable via git, email, or other text-based tools.
+- Plain-text script editor with FmScript syntax highlighting, autocomplete, and validation.
+- DataGrid table/field editor with inline editing, calculation editor, and type/kind selection.
+- Live bidirectional XML viewer -- edit XML or structured data, both stay in sync.
+- Extensible plugin architecture for adding custom panels and tools.
 
 ## Plugins
 
-SharpFM supports plugins via the `SharpFM.Plugin` contract library. Plugins implement `IPanelPlugin` and are loaded from the `plugins/` directory at startup. You can also install and manage plugins from the **View > Manage Plugins...** menu.
+SharpFM supports plugins via the `SharpFM.Plugin` contract library. Plugins are loaded from the `plugins/` directory at startup and can be managed from **Plugins > Manage Plugins...**.
 
-A sample "Clip Inspector" plugin is included to demonstrate the plugin API.
+### Bundled Plugins
+
+- **XML Viewer** -- Live XML panel with syntax highlighting and bidirectional sync (`Ctrl+Shift+X`).
+- **Clip Inspector** -- Displays clip metadata (name, type, element count, size).
 
 ### Writing a Plugin
 
-1. Create a new .NET 8 class library referencing `SharpFM.Plugin`.
-2. Implement `IPanelPlugin` — provide an `Id`, `DisplayName`, and `CreatePanel()` returning an Avalonia `Control`.
-3. Use `IPluginHost` in `Initialize()` to observe clip selection and push XML updates.
-4. Build your DLL and drop it in the `plugins/` directory.
+1. Create a .NET 8 class library referencing `SharpFM.Plugin`.
+2. Implement `IPanelPlugin` -- provide an `Id`, `DisplayName`, `CreatePanel()` returning an Avalonia `Control`.
+3. Use `IPluginHost` in `Initialize()` to observe clip selection changes and content updates.
+4. Optionally register keyboard shortcuts via `KeyBindings` and custom menu actions via `MenuActions`.
+5. Build the DLL and drop it in the `plugins/` directory.
 
 See `src/SharpFM.Plugin.Sample/` for a complete working example.
 
-### License
+### Plugin License
 
 While SharpFM is licensed under GPL v3, plugins that communicate solely through the interfaces in `SharpFM.Plugin` are not required to be GPL-licensed. See the plugin interface source files for the full exception clause.
 
@@ -91,6 +109,6 @@ Logs are stored in `${specialfolder:folder=CommonApplicationData}\SharpFM` and a
 
 ## App Icon
 
-![Sharp FM](Assets/noun-sharp-teeth-monster-4226695.small.png)
+![Sharp FM](src/SharpFM/Assets/noun-sharp-teeth-monster-4226695.small.png)
 
 sharp teeth monster by Kanyanee Watanajitkasem from [Noun Project](https://thenounproject.com/browse/icons/term/sharp-teeth-monster/) (CC BY 3.0)

--- a/src/SharpFM.Plugin.Sample/ClipInspectorPlugin.cs
+++ b/src/SharpFM.Plugin.Sample/ClipInspectorPlugin.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Avalonia.Controls;
 using SharpFM.Plugin;
 
@@ -9,6 +10,7 @@ public class ClipInspectorPlugin : IPanelPlugin
 {
     public string Id => "clip-inspector";
     public string DisplayName => "Clip Inspector";
+    public string Version => GetType().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "0.0.0";
     public IReadOnlyList<PluginKeyBinding> KeyBindings => [];
     public IReadOnlyList<PluginMenuAction> MenuActions => [];
 

--- a/src/SharpFM.Plugin.Sample/SharpFM.Plugin.Sample.csproj
+++ b/src/SharpFM.Plugin.Sample/SharpFM.Plugin.Sample.csproj
@@ -5,6 +5,12 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MinVerMinimumMajorMinor>2.0</MinVerMinimumMajorMinor>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerDefaultPreReleaseIdentifiers>beta.0</MinVerDefaultPreReleaseIdentifiers>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SharpFM.Plugin\SharpFM.Plugin.csproj" />
   </ItemGroup>
@@ -13,5 +19,9 @@
     <PackageReference Include="Avalonia" Version="11.2.4" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.4" />
     <PackageReference Include="FluentAvaloniaUI" Version="2.2.0" />
+    <PackageReference Include="MinVer" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/SharpFM.Plugin.XmlViewer/SharpFM.Plugin.XmlViewer.csproj
+++ b/src/SharpFM.Plugin.XmlViewer/SharpFM.Plugin.XmlViewer.csproj
@@ -5,6 +5,12 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MinVerMinimumMajorMinor>2.0</MinVerMinimumMajorMinor>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerDefaultPreReleaseIdentifiers>beta.0</MinVerDefaultPreReleaseIdentifiers>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SharpFM.Plugin\SharpFM.Plugin.csproj" />
   </ItemGroup>
@@ -16,5 +22,9 @@
     <PackageReference Include="TextMateSharp.Grammars" Version="1.0.66" />
     <PackageReference Include="AvaloniaEdit.TextMate" Version="11.1.0" />
     <PackageReference Include="FluentAvaloniaUI" Version="2.2.0" />
+    <PackageReference Include="MinVer" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/SharpFM.Plugin.XmlViewer/XmlViewerPlugin.cs
+++ b/src/SharpFM.Plugin.XmlViewer/XmlViewerPlugin.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Avalonia.Controls;
 using SharpFM.Plugin;
 
@@ -9,6 +10,7 @@ public class XmlViewerPlugin : IPanelPlugin
 {
     public string Id => "xml-viewer";
     public string DisplayName => "XML Viewer";
+    public string Version => GetType().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "0.0.0";
 
     private IPluginHost? _host;
     private XmlViewerViewModel? _viewModel;

--- a/src/SharpFM.Plugin/IPanelPlugin.cs
+++ b/src/SharpFM.Plugin/IPanelPlugin.cs
@@ -20,9 +20,15 @@ public interface IPanelPlugin : IDisposable
     string Id { get; }
 
     /// <summary>
-    /// Display name shown in the View menu (e.g. "Clip Inspector").
+    /// Display name shown in the Plugins menu (e.g. "Clip Inspector").
     /// </summary>
     string DisplayName { get; }
+
+    /// <summary>
+    /// Plugin version string (e.g. "2.0.0-beta.0"). Shown in the Plugin Manager UI.
+    /// Typically derived from the assembly's informational version.
+    /// </summary>
+    string Version { get; }
 
     /// <summary>
     /// Create the panel control to be hosted in the main window sidebar.

--- a/src/SharpFM.Plugin/SharpFM.Plugin.csproj
+++ b/src/SharpFM.Plugin/SharpFM.Plugin.csproj
@@ -5,7 +5,17 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MinVerMinimumMajorMinor>2.0</MinVerMinimumMajorMinor>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerDefaultPreReleaseIdentifiers>beta.0</MinVerDefaultPreReleaseIdentifiers>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.2.4" />
+    <PackageReference Include="MinVer" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/SharpFM/PluginManager/PluginManagerViewModel.cs
+++ b/src/SharpFM/PluginManager/PluginManagerViewModel.cs
@@ -15,6 +15,7 @@ public class PluginEntry : INotifyPropertyChanged
     public IPanelPlugin Plugin { get; }
     public string Id => Plugin.Id;
     public string DisplayName => Plugin.DisplayName;
+    public string PluginVersion => Plugin.Version;
     public string AssemblyName => Plugin.GetType().Assembly.GetName().Name ?? "(unknown)";
 
     private bool _isActive;

--- a/src/SharpFM/PluginManager/PluginManagerWindow.axaml
+++ b/src/SharpFM/PluginManager/PluginManagerWindow.axaml
@@ -30,9 +30,9 @@
                                     <TextBlock Classes="Fluent2Body" Text="{Binding DisplayName}" FontWeight="SemiBold" />
                                     <TextBlock Classes="Fluent2Caption" Opacity="0.7">
                                         <TextBlock.Text>
-                                            <MultiBinding StringFormat="{}{0} ({1})">
+                                            <MultiBinding StringFormat="{}{0} v{1}">
                                                 <Binding Path="Id" />
-                                                <Binding Path="AssemblyName" />
+                                                <Binding Path="PluginVersion" />
                                             </MultiBinding>
                                         </TextBlock.Text>
                                     </TextBlock>

--- a/src/SharpFM/SharpFM.csproj
+++ b/src/SharpFM/SharpFM.csproj
@@ -39,7 +39,7 @@
   </Target>
 
   <PropertyGroup>
-    <MinVerMinimumMajorMinor>1.0</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>2.0</MinVerMinimumMajorMinor>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerDefaultPreReleaseIdentifiers>beta.0</MinVerDefaultPreReleaseIdentifiers>
   </PropertyGroup>

--- a/tests/SharpFM.Plugin.Tests/PluginManagerViewModelTests.cs
+++ b/tests/SharpFM.Plugin.Tests/PluginManagerViewModelTests.cs
@@ -11,6 +11,7 @@ public class PluginManagerViewModelTests
     {
         public string Id { get; set; } = "stub";
         public string DisplayName { get; set; } = "Stub";
+        public string Version => "1.0.0-test";
         public IReadOnlyList<PluginKeyBinding> KeyBindings => [];
         public IReadOnlyList<PluginMenuAction> MenuActions => [];
         public Control CreatePanel() => new TextBlock();

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -208,6 +208,7 @@ public class MainWindowViewModelTests
     {
         public string Id { get; set; } = "stub";
         public string DisplayName => "Stub Plugin";
+        public string Version => "1.0.0-test";
         public IReadOnlyList<PluginKeyBinding> TestKeyBindings { get; set; } = [];
         public IReadOnlyList<PluginKeyBinding> KeyBindings => TestKeyBindings;
         public IReadOnlyList<PluginMenuAction> MenuActions => [];


### PR DESCRIPTION
## Summary

- Rewrite README to match current File/Edit/Plugins menu structure
- Add keyboard shortcuts table and menu reference
- Document bundled plugins (XML Viewer, Clip Inspector) and plugin authoring
- Bump MinVer to v2.0 across all projects (SharpFM, Plugin, Plugin.Sample, Plugin.XmlViewer)
- Add `Version` property to `IPanelPlugin` interface, shown in Plugin Manager UI
- Fix asset path for project restructure

## Test plan

- [x] `dotnet build && dotnet test` passes (198 tests)
- [x] Plugin Manager shows version for each loaded plugin
- [x] README accurately reflects current menu layout and workflows