### PR TITLE
feat: add clip deletion from the UI

### DIFF
--- a/src/SharpFM/MainWindow.axaml
+++ b/src/SharpFM/MainWindow.axaml
@@ -21,6 +21,7 @@
         <KeyBinding Gesture="Ctrl+N" Command="{Binding NewScriptCommand}" />
         <KeyBinding Gesture="Ctrl+Shift+N" Command="{Binding NewTableCommand}" />
         <KeyBinding Gesture="Ctrl+Shift+C" Command="{Binding CopySelectedToClip}" />
+        <KeyBinding Gesture="Delete" Command="{Binding DeleteSelectedClip}" />
     </Window.KeyBindings>
 
     <DockPanel>
@@ -39,6 +40,8 @@
                 <MenuItem Command="{Binding CopySelectedToClip}" Header="Copy to FileMaker" InputGesture="Ctrl+Shift+C" />
                 <Separator />
                 <MenuItem Command="{Binding CopyAsClass}" Header="Copy as C# Class" />
+                <Separator />
+                <MenuItem Command="{Binding DeleteSelectedClip}" Header="Delete Clip" InputGesture="Delete" />
             </MenuItem>
             <MenuItem x:Name="pluginsMenu" Header="_Plugins">
                 <!-- Plugin menu items are added dynamically in code-behind -->
@@ -138,6 +141,20 @@
                                     Classes="Fluent2"
                                     ItemsSource="{Binding FilteredClips}"
                                     SelectedItem="{Binding SelectedClip}">
+                                    <ListBox.ContextMenu>
+                                        <ContextMenu>
+                                            <MenuItem
+                                                Command="{Binding CopySelectedToClip}"
+                                                Header="Copy to FileMaker" />
+                                            <MenuItem
+                                                Command="{Binding CopyAsClass}"
+                                                Header="Copy as C# Class" />
+                                            <Separator />
+                                            <MenuItem
+                                                Command="{Binding DeleteSelectedClip}"
+                                                Header="Delete Clip" />
+                                        </ContextMenu>
+                                    </ListBox.ContextMenu>
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
                                             <Border 

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -132,6 +132,20 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
             }
 
             clipContext.SaveChanges();
+
+            // Remove files for clips that no longer exist in memory
+            var activeNames = new HashSet<string>(
+                FileMakerClips.Select(c => $"{c.Name}.{c.ClipType}"),
+                StringComparer.OrdinalIgnoreCase);
+
+            foreach (var file in Directory.EnumerateFiles(CurrentPath))
+            {
+                if (!activeNames.Contains(Path.GetFileName(file)))
+                {
+                    File.Delete(file);
+                }
+            }
+
             ShowStatus($"Saved {FileMakerClips.Count} clip(s) to {CurrentPath}");
         }
         catch (Exception e)
@@ -155,6 +169,20 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
 
     private static readonly string EmptyTableXml =
         "<fmxmlsnippet type=\"FMObjectList\"><BaseTable name=\"NewTable\"></BaseTable></fmxmlsnippet>";
+
+    public void DeleteSelectedClip()
+    {
+        if (SelectedClip is null)
+        {
+            ShowStatus("No clip selected");
+            return;
+        }
+
+        var name = SelectedClip.Name;
+        FileMakerClips.Remove(SelectedClip);
+        SelectedClip = null;
+        ShowStatus($"Deleted clip '{name}'");
+    }
 
     public void NewScriptCommand()
     {

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -123,6 +123,45 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void DeleteSelectedClip_RemovesClipFromCollection()
+    {
+        var vm = CreateVm();
+        vm.NewScriptCommand();
+        var clip = vm.SelectedClip;
+        Assert.NotNull(clip);
+
+        vm.DeleteSelectedClip();
+
+        Assert.DoesNotContain(clip, vm.FileMakerClips);
+        Assert.Null(vm.SelectedClip);
+        Assert.Contains("Deleted clip", vm.StatusMessage);
+    }
+
+    [Fact]
+    public void DeleteSelectedClip_NoSelection_ShowsStatus()
+    {
+        var vm = CreateVm();
+        vm.SelectedClip = null;
+
+        vm.DeleteSelectedClip();
+
+        Assert.Equal("No clip selected", vm.StatusMessage);
+    }
+
+    [Fact]
+    public void DeleteSelectedClip_RemovesFromFilteredClips()
+    {
+        var vm = CreateVm();
+        vm.NewScriptCommand();
+        var clip = vm.SelectedClip!;
+        Assert.Contains(clip, vm.FilteredClips);
+
+        vm.DeleteSelectedClip();
+
+        Assert.DoesNotContain(clip, vm.FilteredClips);
+    }
+
+    [Fact]
     public void SearchText_FiltersClips()
     {
         var vm = CreateVm();


### PR DESCRIPTION
## Summary
- Add `DeleteSelectedClip` command to remove the selected clip from the collection
- Wire up Delete key binding, Edit > Delete Clip menu item, and right-click context menu on the clip list
- Clean up orphaned files from disk when saving after deletions

Closes #148