### PR TITLE
feat: expand plugin architecture with event, persistence, and transform types

### DIFF
--- a/docs/plugins/event-plugins.md
+++ b/docs/plugins/event-plugins.md
@@ -1,0 +1,72 @@
+# Event Plugins
+
+Event plugins are headless — they react to host events with no UI panel.
+
+## Interface
+
+```csharp
+public interface IEventPlugin : IPlugin { }
+```
+
+`IEventPlugin` is a marker interface. All behavior comes from subscribing to `IPluginHost` events in `Initialize()` and unsubscribing in `Dispose()`.
+
+## When to Use
+
+- Auto-formatters that reformat XML on clip selection
+- Linters that validate clip structure and post diagnostics
+- Sync agents that mirror clips to an external system
+- Analytics or telemetry
+
+## Available Events
+
+| Event | When |
+|-------|------|
+| `SelectedClipChanged` | User selects a different clip |
+| `ClipContentChanged` | Clip XML changes (user edit or plugin push) |
+| `ClipCollectionChanged` | Clips added, removed, or reloaded |
+
+## Host Capabilities
+
+- `AllClips` — read the full clip collection for bulk operations
+- `ShowStatus(message)` — display feedback in the status bar
+- `UpdateSelectedClipXml(xml, pluginId)` — push XML changes back to the editor
+
+## Example: Auto-Formatter
+
+```csharp
+public class AutoFormatPlugin : IEventPlugin
+{
+    public string Id => "auto-format";
+    public string DisplayName => "Auto Formatter";
+    public string Version => "1.0.0";
+    public IReadOnlyList<PluginKeyBinding> KeyBindings => [];
+    public IReadOnlyList<PluginMenuAction> MenuActions => [];
+
+    private IPluginHost? _host;
+
+    public void Initialize(IPluginHost host)
+    {
+        _host = host;
+        _host.SelectedClipChanged += OnClipChanged;
+    }
+
+    private void OnClipChanged(object? sender, ClipInfo? clip)
+    {
+        if (clip is null) return;
+        var formatted = FormatXml(clip.Xml);
+        if (formatted != clip.Xml)
+        {
+            _host!.UpdateSelectedClipXml(formatted, Id);
+            _host.ShowStatus("Clip auto-formatted");
+        }
+    }
+
+    private static string FormatXml(string xml) => xml; // your formatting logic
+
+    public void Dispose()
+    {
+        if (_host is not null)
+            _host.SelectedClipChanged -= OnClipChanged;
+    }
+}
+```

--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -1,0 +1,69 @@
+# IPluginHost API Reference
+
+The `IPluginHost` interface is provided to plugins during `Initialize()`. It exposes the host application's state and services.
+
+## Properties
+
+### `ClipInfo? SelectedClip`
+
+The currently selected clip, or `null` if nothing is selected. Returns a snapshot — reading it multiple times may return different instances if the clip changed.
+
+### `IReadOnlyList<ClipInfo> AllClips`
+
+All clips currently loaded in the application. Useful for plugins that operate across the full clip set (linters, search indexers, sync agents).
+
+## Events
+
+### `SelectedClipChanged`
+
+```csharp
+event EventHandler<ClipInfo?> SelectedClipChanged;
+```
+
+Raised when the user selects a different clip in the list. The argument is the new clip, or `null` if deselected.
+
+### `ClipContentChanged`
+
+```csharp
+event EventHandler<ClipContentChangedArgs> ClipContentChanged;
+```
+
+Raised when clip content changes. Check `args.Origin` to determine the source:
+- `"editor"` — user edited in the structured editor (debounced)
+- Plugin ID — a plugin pushed XML changes (immediate)
+
+```csharp
+public record ClipContentChangedArgs(ClipInfo Clip, string Origin, bool IsPartial);
+```
+
+`IsPartial` is `true` when the XML was produced from an incomplete parse (e.g., user is mid-edit in the script editor).
+
+### `ClipCollectionChanged`
+
+```csharp
+event EventHandler? ClipCollectionChanged;
+```
+
+Raised when clips are added, removed, or the collection is reloaded.
+
+## Methods
+
+### `UpdateSelectedClipXml(string xml, string originPluginId)`
+
+Replace the XML content of the currently selected clip. The host syncs the new XML back to the structured editor automatically. Pass your plugin's `Id` as `originPluginId` for origin tagging — you'll receive your own change back via `ClipContentChanged` but can skip it by checking `args.Origin == Id`.
+
+### `RefreshSelectedClip() -> ClipInfo?`
+
+Flush the editor's in-progress state to XML and return a fresh snapshot. Use this before reading `SelectedClip` if you need XML that reflects any uncommitted edits in the structured editors.
+
+### `ShowStatus(string message)`
+
+Display a message in the status bar. Use this for user-visible feedback. The message auto-clears after a few seconds.
+
+## ClipInfo
+
+```csharp
+public record ClipInfo(string Name, string ClipType, string Xml);
+```
+
+A read-only snapshot of clip metadata and content. `ClipType` is the FileMaker clipboard format (e.g., `"Mac-XMSS"` for script steps, `"Mac-XMTB"` for tables).

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -1,0 +1,51 @@
+# SharpFM Plugin System
+
+SharpFM supports four types of plugins, all sharing a common base interface (`IPlugin`) for metadata and lifecycle.
+
+## Plugin Types
+
+| Type | Interface | Purpose |
+|------|-----------|---------|
+| **Panel** | `IPanelPlugin` | Sidebar UI panels that display clip data |
+| **Event** | `IEventPlugin` | Headless handlers that react to host events |
+| **Persistence** | `IPersistencePlugin` | Alternative storage backends (cloud, database) |
+| **Transform** | `IClipTransformPlugin` | Modify clip XML during import/export |
+
+## Getting Started
+
+### 1. Create a Class Library
+
+Create a new .NET 8 class library and reference `SharpFM.Plugin`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="path/to/SharpFM.Plugin.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+### 2. Implement a Plugin Interface
+
+Choose the interface that matches your use case and implement it. Every plugin must provide:
+
+- `Id` — unique identifier (e.g., `"my-plugin"`)
+- `DisplayName` — shown in the Plugins menu
+- `Version` — shown in the Plugin Manager
+- `Initialize(IPluginHost host)` — called once at startup
+- `Dispose()` — cleanup when unloaded
+
+### 3. Build and Install
+
+Build your plugin as a DLL and install it via the Plugin Manager ("Install from File...") or copy it to the `plugins/` directory next to the SharpFM executable.
+
+## Discovery
+
+SharpFM scans the `plugins/` directory at startup for `.dll` files. Each assembly is loaded in its own `AssemblyLoadContext` and reflected for types implementing `IPlugin` subtypes. Each class is categorized into exactly one plugin type based on the interface it implements.
+
+## Licensing
+
+The `SharpFM.Plugin` project is GPL with a **plugin exception**: plugins that implement these interfaces are not subject to the GPL and may use any license, including proprietary.

--- a/docs/plugins/panel-plugins.md
+++ b/docs/plugins/panel-plugins.md
@@ -1,0 +1,73 @@
+# Panel Plugins
+
+Panel plugins provide a sidebar UI panel in the SharpFM main window.
+
+## Interface
+
+```csharp
+public interface IPanelPlugin : IPlugin
+{
+    Control CreatePanel();
+}
+```
+
+`CreatePanel()` is called once when the user activates the plugin. Only one panel plugin can be active at a time. Toggling the same plugin closes it; toggling a different one switches the panel content.
+
+## Lifecycle
+
+1. `Initialize(IPluginHost host)` — subscribe to host events here
+2. `CreatePanel()` — create your Avalonia `Control` (called when plugin is toggled on)
+3. `Dispose()` — unsubscribe from events and clean up
+
+## Subscribing to Events
+
+```csharp
+public void Initialize(IPluginHost host)
+{
+    _host = host;
+    _host.SelectedClipChanged += OnClipChanged;
+    _host.ClipContentChanged += OnContentChanged;
+}
+```
+
+## Bidirectional Sync
+
+If your plugin edits clip XML, use origin tagging to avoid feedback loops:
+
+```csharp
+// Push changes to the host
+_host.UpdateSelectedClipXml(newXml, Id);
+
+// Skip your own updates
+private void OnContentChanged(object? sender, ClipContentChangedArgs args)
+{
+    if (args.Origin == Id) return; // I caused this change
+    _viewModel.LoadClip(args.Clip);
+}
+```
+
+## Example: Minimal Read-Only Panel
+
+```csharp
+public class MyPlugin : IPanelPlugin
+{
+    public string Id => "my-plugin";
+    public string DisplayName => "My Plugin";
+    public string Version => "1.0.0";
+    public IReadOnlyList<PluginKeyBinding> KeyBindings => [];
+    public IReadOnlyList<PluginMenuAction> MenuActions => [];
+
+    private IPluginHost? _host;
+
+    public void Initialize(IPluginHost host) => _host = host;
+
+    public Control CreatePanel()
+    {
+        var text = new TextBlock { Text = _host?.SelectedClip?.Name ?? "No clip" };
+        _host!.SelectedClipChanged += (_, clip) => text.Text = clip?.Name ?? "No clip";
+        return text;
+    }
+
+    public void Dispose() { }
+}
+```

--- a/docs/plugins/persistence-plugins.md
+++ b/docs/plugins/persistence-plugins.md
@@ -1,0 +1,85 @@
+# Persistence Plugins
+
+Persistence plugins provide alternative storage backends for clips.
+
+## Interfaces
+
+### IPersistencePlugin
+
+```csharp
+public interface IPersistencePlugin : IPlugin
+{
+    IClipRepository CreateRepository();
+}
+```
+
+The plugin handles discovery and lifecycle. `CreateRepository()` is called when the user selects this storage provider.
+
+### IClipRepository
+
+```csharp
+public interface IClipRepository
+{
+    string ProviderName { get; }
+    string CurrentLocation { get; }
+    bool SupportsLocationPicker { get; }
+    Task<IReadOnlyList<ClipData>> LoadClipsAsync();
+    Task SaveClipsAsync(IReadOnlyList<ClipData> clips);
+    Task<string?> PickLocationAsync();
+}
+```
+
+The repository handles all data operations. Methods are async to support remote backends.
+
+### ClipData
+
+```csharp
+public record ClipData(string Name, string ClipType, string Xml);
+```
+
+The persistence DTO. Separate from `ClipInfo` (which is used for plugin notifications) so the two can evolve independently.
+
+## Built-In vs Plugin Storage
+
+The built-in file system storage (`ClipRepository`) implements `IClipRepository` directly — it is **not** a plugin. Plugin-provided backends come through `IPersistencePlugin`.
+
+At startup, the host builds a list of available repositories:
+1. The built-in file system repository
+2. One from each loaded `IPersistencePlugin` via `CreateRepository()`
+
+## Example: Cloud API Storage Plugin
+
+```csharp
+public class CloudStoragePlugin : IPersistencePlugin
+{
+    public string Id => "cloud-storage";
+    public string DisplayName => "Cloud Storage";
+    public string Version => "1.0.0";
+    public IReadOnlyList<PluginKeyBinding> KeyBindings => [];
+    public IReadOnlyList<PluginMenuAction> MenuActions => [];
+
+    public void Initialize(IPluginHost host) { }
+    public IClipRepository CreateRepository() => new CloudRepository();
+    public void Dispose() { }
+}
+
+public class CloudRepository : IClipRepository
+{
+    public string ProviderName => "Cloud API";
+    public string CurrentLocation => "https://api.example.com/clips";
+    public bool SupportsLocationPicker => false;
+
+    public async Task<IReadOnlyList<ClipData>> LoadClipsAsync()
+    {
+        // Fetch clips from your API
+        return [];
+    }
+
+    public async Task SaveClipsAsync(IReadOnlyList<ClipData> clips)
+    {
+        // Push clips to your API
+    }
+
+    public Task<string?> PickLocationAsync() => Task.FromResult<string?>(null);
+}
+```

--- a/docs/plugins/transform-plugins.md
+++ b/docs/plugins/transform-plugins.md
@@ -1,0 +1,63 @@
+# Transform Plugins
+
+Transform plugins modify clip XML during import (paste/load) and export (copy to clipboard) operations.
+
+## Interface
+
+```csharp
+public interface IClipTransformPlugin : IPlugin
+{
+    Task<string> OnImportAsync(string clipType, string xml);
+    Task<string> OnExportAsync(string clipType, string xml);
+    bool IsEnabled { get; set; }
+}
+```
+
+## When to Use
+
+- Strip internal FileMaker IDs when pasting clips between files
+- Inject boilerplate fields into table definitions
+- Rename table/field references during refactoring
+- Sanitize clips before sharing with other developers
+- Convert between FileMaker versions
+
+## Behavior
+
+- **Import**: Runs when clips are pasted from FileMaker or loaded from storage
+- **Export**: Runs when clips are copied to the FileMaker clipboard
+- **Ordering**: Transforms run in plugin load order (DLL discovery order)
+- **Passthrough**: Return the input `xml` unchanged to skip transformation
+- **IsEnabled**: Users can toggle transforms on/off without uninstalling
+
+## Example: Strip Internal IDs
+
+```csharp
+public class StripIdsPlugin : IClipTransformPlugin
+{
+    public string Id => "strip-ids";
+    public string DisplayName => "Strip Internal IDs";
+    public string Version => "1.0.0";
+    public bool IsEnabled { get; set; } = true;
+    public IReadOnlyList<PluginKeyBinding> KeyBindings => [];
+    public IReadOnlyList<PluginMenuAction> MenuActions => [];
+
+    public void Initialize(IPluginHost host) { }
+
+    public Task<string> OnImportAsync(string clipType, string xml)
+    {
+        if (!IsEnabled) return Task.FromResult(xml);
+
+        // Strip id="..." attributes from elements
+        var cleaned = Regex.Replace(xml, @"\s+id=""\d+""", "");
+        return Task.FromResult(cleaned);
+    }
+
+    public Task<string> OnExportAsync(string clipType, string xml)
+    {
+        // No transformation on export
+        return Task.FromResult(xml);
+    }
+
+    public void Dispose() { }
+}
+```

--- a/src/SharpFM.Plugin/ClipData.cs
+++ b/src/SharpFM.Plugin/ClipData.cs
@@ -1,0 +1,15 @@
+// This file is part of SharpFM and is licensed under the GNU General Public License v3.
+//
+// Plugin Exception: You may create plugins that implement these interfaces without those
+// plugins being subject to the GPL. Such plugins may use any license, including proprietary.
+
+namespace SharpFM.Plugin;
+
+/// <summary>
+/// Data transfer object for clip persistence. Used by <see cref="IClipRepository"/>
+/// implementations to load and save clips.
+/// </summary>
+/// <param name="Name">Clip display name (filename without extension for file-based storage).</param>
+/// <param name="ClipType">Clipboard format identifier (e.g. "Mac-XMSS").</param>
+/// <param name="Xml">Raw XML content of the clip.</param>
+public record ClipData(string Name, string ClipType, string Xml);

--- a/src/SharpFM.Plugin/IClipRepository.cs
+++ b/src/SharpFM.Plugin/IClipRepository.cs
@@ -1,0 +1,50 @@
+// This file is part of SharpFM and is licensed under the GNU General Public License v3.
+//
+// Plugin Exception: You may create plugins that implement these interfaces without those
+// plugins being subject to the GPL. Such plugins may use any license, including proprietary.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SharpFM.Plugin;
+
+/// <summary>
+/// Abstraction for clip storage. The built-in file system storage and
+/// plugin-provided backends both implement this interface.
+/// </summary>
+public interface IClipRepository
+{
+    /// <summary>
+    /// Human-readable name for this storage backend (e.g. "Local Files", "Cloud API").
+    /// </summary>
+    string ProviderName { get; }
+
+    /// <summary>
+    /// Display string for the current storage location (e.g., folder path, URL).
+    /// </summary>
+    string CurrentLocation { get; }
+
+    /// <summary>
+    /// Whether this provider supports browsing/switching locations
+    /// (e.g., picking a different folder, connecting to a different server).
+    /// </summary>
+    bool SupportsLocationPicker { get; }
+
+    /// <summary>
+    /// Load all clips from the storage backend.
+    /// </summary>
+    Task<IReadOnlyList<ClipData>> LoadClipsAsync();
+
+    /// <summary>
+    /// Save all clips to the storage backend. The implementation should handle
+    /// creates, updates, and deletes (i.e., clips not in the list should be removed).
+    /// </summary>
+    Task SaveClipsAsync(IReadOnlyList<ClipData> clips);
+
+    /// <summary>
+    /// Open a location picker and switch to the selected location.
+    /// Only called if <see cref="SupportsLocationPicker"/> is true.
+    /// Returns the display string for the new location, or null if cancelled.
+    /// </summary>
+    Task<string?> PickLocationAsync();
+}

--- a/src/SharpFM.Plugin/IClipTransformPlugin.cs
+++ b/src/SharpFM.Plugin/IClipTransformPlugin.cs
@@ -1,0 +1,34 @@
+// This file is part of SharpFM and is licensed under the GNU General Public License v3.
+//
+// Plugin Exception: You may create plugins that implement these interfaces without those
+// plugins being subject to the GPL. Such plugins may use any license, including proprietary.
+
+using System.Threading.Tasks;
+
+namespace SharpFM.Plugin;
+
+/// <summary>
+/// A plugin that transforms clip XML during import or export operations.
+/// Transforms run in plugin load order. Use <see cref="IsEnabled"/> to allow
+/// users to toggle transforms without uninstalling.
+/// </summary>
+public interface IClipTransformPlugin : IPlugin
+{
+    /// <summary>
+    /// Transform clip XML when a clip is imported (pasted from FileMaker or loaded from storage).
+    /// Return the input unchanged to skip transformation.
+    /// </summary>
+    Task<string> OnImportAsync(string clipType, string xml);
+
+    /// <summary>
+    /// Transform clip XML when a clip is exported (copied to FileMaker clipboard).
+    /// Return the input unchanged to skip transformation.
+    /// </summary>
+    Task<string> OnExportAsync(string clipType, string xml);
+
+    /// <summary>
+    /// Whether this transformer is currently enabled.
+    /// The user can toggle transformers on/off without uninstalling them.
+    /// </summary>
+    bool IsEnabled { get; set; }
+}

--- a/src/SharpFM.Plugin/IEventPlugin.cs
+++ b/src/SharpFM.Plugin/IEventPlugin.cs
@@ -1,0 +1,13 @@
+// This file is part of SharpFM and is licensed under the GNU General Public License v3.
+//
+// Plugin Exception: You may create plugins that implement these interfaces without those
+// plugins being subject to the GPL. Such plugins may use any license, including proprietary.
+
+namespace SharpFM.Plugin;
+
+/// <summary>
+/// A headless plugin that reacts to host events with no UI panel.
+/// Subscribe to <see cref="IPluginHost"/> events in <see cref="IPlugin.Initialize"/>
+/// and unsubscribe in <see cref="System.IDisposable.Dispose"/>.
+/// </summary>
+public interface IEventPlugin : IPlugin { }

--- a/src/SharpFM.Plugin/IPanelPlugin.cs
+++ b/src/SharpFM.Plugin/IPanelPlugin.cs
@@ -3,55 +3,19 @@
 // Plugin Exception: You may create plugins that implement these interfaces without those
 // plugins being subject to the GPL. Such plugins may use any license, including proprietary.
 
-using System;
-using System.Collections.Generic;
 using Avalonia.Controls;
 
 namespace SharpFM.Plugin;
 
 /// <summary>
 /// A plugin that provides a dockable side panel in the SharpFM UI.
+/// Inherits common metadata and lifecycle from <see cref="IPlugin"/>.
 /// </summary>
-public interface IPanelPlugin : IDisposable
+public interface IPanelPlugin : IPlugin
 {
     /// <summary>
-    /// Unique identifier for this plugin (e.g. "clip-inspector", "ai-assistant").
-    /// </summary>
-    string Id { get; }
-
-    /// <summary>
-    /// Display name shown in the Plugins menu (e.g. "Clip Inspector").
-    /// </summary>
-    string DisplayName { get; }
-
-    /// <summary>
-    /// Plugin version string (e.g. "2.0.0-beta.0"). Shown in the Plugin Manager UI.
-    /// Typically derived from the assembly's informational version.
-    /// </summary>
-    string Version { get; }
-
-    /// <summary>
     /// Create the panel control to be hosted in the main window sidebar.
-    /// Called once after <see cref="Initialize"/>.
+    /// Called once after <see cref="IPlugin.Initialize"/>.
     /// </summary>
     Control CreatePanel();
-
-    /// <summary>
-    /// Initialize the plugin with access to host services.
-    /// Called once at startup before <see cref="CreatePanel"/>.
-    /// </summary>
-    void Initialize(IPluginHost host);
-
-    /// <summary>
-    /// Keyboard shortcuts this plugin wants registered in the host window.
-    /// The host registers these when the plugin is loaded. Return empty for no shortcuts.
-    /// </summary>
-    IReadOnlyList<PluginKeyBinding> KeyBindings { get; }
-
-    /// <summary>
-    /// Custom menu actions shown under this plugin's entry in the Plugins menu.
-    /// If empty, the plugin shows as a simple toggle item. If non-empty, it shows
-    /// as a submenu with "Toggle Panel" plus these custom actions.
-    /// </summary>
-    IReadOnlyList<PluginMenuAction> MenuActions { get; }
 }

--- a/src/SharpFM.Plugin/IPersistencePlugin.cs
+++ b/src/SharpFM.Plugin/IPersistencePlugin.cs
@@ -1,0 +1,20 @@
+// This file is part of SharpFM and is licensed under the GNU General Public License v3.
+//
+// Plugin Exception: You may create plugins that implement these interfaces without those
+// plugins being subject to the GPL. Such plugins may use any license, including proprietary.
+
+namespace SharpFM.Plugin;
+
+/// <summary>
+/// A plugin that provides an alternative clip storage backend.
+/// The host registers this as an available persistence provider
+/// that users can switch to via the UI.
+/// </summary>
+public interface IPersistencePlugin : IPlugin
+{
+    /// <summary>
+    /// Create and return the repository instance for this storage backend.
+    /// Called when the user selects this provider.
+    /// </summary>
+    IClipRepository CreateRepository();
+}

--- a/src/SharpFM.Plugin/IPlugin.cs
+++ b/src/SharpFM.Plugin/IPlugin.cs
@@ -1,0 +1,49 @@
+// This file is part of SharpFM and is licensed under the GNU General Public License v3.
+//
+// Plugin Exception: You may create plugins that implement these interfaces without those
+// plugins being subject to the GPL. Such plugins may use any license, including proprietary.
+
+using System;
+using System.Collections.Generic;
+
+namespace SharpFM.Plugin;
+
+/// <summary>
+/// Base interface for all SharpFM plugins. Provides common metadata and lifecycle.
+/// </summary>
+public interface IPlugin : IDisposable
+{
+    /// <summary>
+    /// Unique identifier for this plugin (e.g. "clip-inspector", "ai-assistant").
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Display name shown in the Plugins menu (e.g. "Clip Inspector").
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// Plugin version string (e.g. "2.0.0-beta.0"). Shown in the Plugin Manager UI.
+    /// </summary>
+    string Version { get; }
+
+    /// <summary>
+    /// Initialize the plugin with access to host services.
+    /// Called once at startup before any other interaction.
+    /// </summary>
+    void Initialize(IPluginHost host);
+
+    /// <summary>
+    /// Keyboard shortcuts this plugin wants registered in the host window.
+    /// The host registers these when the plugin is loaded. Return empty for no shortcuts.
+    /// </summary>
+    IReadOnlyList<PluginKeyBinding> KeyBindings { get; }
+
+    /// <summary>
+    /// Custom menu actions shown under this plugin's entry in the Plugins menu.
+    /// If empty, the plugin shows as a simple toggle item. If non-empty, it shows
+    /// as a submenu with "Toggle Panel" plus these custom actions.
+    /// </summary>
+    IReadOnlyList<PluginMenuAction> MenuActions { get; }
+}

--- a/src/SharpFM.Plugin/IPluginHost.cs
+++ b/src/SharpFM.Plugin/IPluginHost.cs
@@ -4,6 +4,7 @@
 // plugins being subject to the GPL. Such plugins may use any license, including proprietary.
 
 using System;
+using System.Collections.Generic;
 
 namespace SharpFM.Plugin;
 
@@ -45,4 +46,22 @@ public interface IPluginHost
     /// Debounced for editor edits; immediate for plugin pushes.
     /// </summary>
     event EventHandler<ClipContentChangedArgs> ClipContentChanged;
+
+    /// <summary>
+    /// All clips currently loaded in the application.
+    /// Useful for event plugins that need to operate across the full clip set.
+    /// </summary>
+    IReadOnlyList<ClipInfo> AllClips { get; }
+
+    /// <summary>
+    /// Raised when the clip collection changes (clips added, removed, or reloaded).
+    /// </summary>
+    event EventHandler? ClipCollectionChanged;
+
+    /// <summary>
+    /// Request the host to show a status message in the status bar.
+    /// Plugins should use this for user-visible feedback rather than
+    /// implementing their own notification UI.
+    /// </summary>
+    void ShowStatus(string message);
 }

--- a/src/SharpFM/App.axaml.cs
+++ b/src/SharpFM/App.axaml.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using SharpFM.Models;
+using SharpFM.Plugin;
 using SharpFM.ViewModels;
 using Microsoft.Extensions.Logging;
 using NLog.Extensions.Logging;
@@ -41,7 +44,16 @@ public partial class App : Application
             var pluginHost = new PluginHost(viewModel);
             var pluginService = new PluginService(logger);
             pluginService.LoadPlugins(pluginHost);
-            viewModel.PanelPlugins = pluginService.LoadedPlugins;
+
+            // Wire up all plugin types
+            viewModel.PanelPlugins = pluginService.PanelPlugins;
+            viewModel.TransformPlugins = pluginService.TransformPlugins;
+
+            // Build repository list: built-in + plugin-provided
+            var repos = new List<IClipRepository> { viewModel.ActiveRepository };
+            foreach (var pp in pluginService.PersistencePlugins)
+                repos.Add(pp.CreateRepository());
+            viewModel.AvailableRepositories = repos;
 
             // Give the window access to plugin services for the manager dialog
             if (desktop.MainWindow is MainWindow mainWindow)

--- a/src/SharpFM/Models/ClipRepository.cs
+++ b/src/SharpFM/Models/ClipRepository.cs
@@ -1,83 +1,93 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using NLog;
+using SharpFM.Plugin;
 
 namespace SharpFM.Models;
 
 /// <summary>
-/// Clip File Repository.
+/// File-system-based clip repository. Stores each clip as a file in a directory.
 /// </summary>
-[ExcludeFromCodeCoverage]
-public class ClipRepository
+public class ClipRepository : IClipRepository
 {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
-    /// <summary>
-    /// Clips stored in the specified folder.
-    /// </summary>
-    public ICollection<Clip> Clips { get; init; }
+    public string ProviderName => "Local Files";
+
+    public string CurrentLocation => ClipPath;
+
+    public bool SupportsLocationPicker => false;
 
     /// <summary>
-    /// Database path.
+    /// Directory path where clip files are stored.
     /// </summary>
     public string ClipPath { get; }
 
-    /// <summary>
-    /// Constructor.
-    /// </summary>
     public ClipRepository(string path)
     {
-        // ensure the directory exists
         if (!Directory.Exists(path))
         {
             Directory.CreateDirectory(path);
         }
 
         ClipPath = path;
-
-        // init clips to empty
-        Clips = [];
     }
 
-    /// <summary>
-    /// Load clips from the path specified by <see cref="ClipPath"/>.
-    /// </summary>
-    public void LoadClips()
+    public Task<IReadOnlyList<ClipData>> LoadClipsAsync()
     {
+        var clips = new List<ClipData>();
+
         foreach (var clipFile in Directory.EnumerateFiles(ClipPath))
         {
             try
             {
                 var fi = new FileInfo(clipFile);
 
-                var clip = new Clip
-                {
-                    ClipName = fi.Name.Replace(fi.Extension, string.Empty),
-                    ClipType = fi.Extension.Replace(".", string.Empty),
-                    ClipXml = File.ReadAllText(clipFile)
-                };
-
-                Clips.Add(clip);
+                clips.Add(new ClipData(
+                    Name: fi.Name.Replace(fi.Extension, string.Empty),
+                    ClipType: fi.Extension.Replace(".", string.Empty),
+                    Xml: File.ReadAllText(clipFile)));
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to load clip file: {File}", clipFile);
             }
         }
+
+        return Task.FromResult<IReadOnlyList<ClipData>>(clips);
     }
 
-    /// <summary>
-    /// Write all clips to their associated clip type files in the path specified by <see cref="ClipPath"/>.
-    /// </summary>
-    public void SaveChanges()
+    public Task SaveClipsAsync(IReadOnlyList<ClipData> clips)
     {
-        foreach (var clip in Clips)
+        foreach (var clip in clips)
         {
-            var clipPath = Path.Combine(ClipPath, $"{clip.ClipName}.{clip.ClipType}");
-
-            File.WriteAllText(clipPath, clip.ClipXml);
+            var clipPath = Path.Combine(ClipPath, $"{clip.Name}.{clip.ClipType}");
+            File.WriteAllText(clipPath, clip.Xml);
         }
+
+        // Remove files for clips that no longer exist
+        var activeNames = new HashSet<string>(
+            clips.Select(c => $"{c.Name}.{c.ClipType}"),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in Directory.EnumerateFiles(ClipPath))
+        {
+            if (!activeNames.Contains(Path.GetFileName(file)))
+            {
+                File.Delete(file);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<string?> PickLocationAsync()
+    {
+        // File-based repo doesn't handle its own location picking.
+        // The host manages folder selection and creates a new ClipRepository.
+        return Task.FromResult<string?>(null);
     }
 }

--- a/src/SharpFM/PluginManager/PluginManagerViewModel.cs
+++ b/src/SharpFM/PluginManager/PluginManagerViewModel.cs
@@ -12,11 +12,20 @@ public class PluginEntry : INotifyPropertyChanged
     private void Notify([CallerMemberName] string name = "") =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 
-    public IPanelPlugin Plugin { get; }
+    public IPlugin Plugin { get; }
     public string Id => Plugin.Id;
     public string DisplayName => Plugin.DisplayName;
     public string PluginVersion => Plugin.Version;
     public string AssemblyName => Plugin.GetType().Assembly.GetName().Name ?? "(unknown)";
+
+    public string PluginType => Plugin switch
+    {
+        IPanelPlugin => "Panel",
+        IEventPlugin => "Event",
+        IPersistencePlugin => "Storage",
+        IClipTransformPlugin => "Transform",
+        _ => "Unknown"
+    };
 
     private bool _isActive;
     public bool IsActive
@@ -25,7 +34,7 @@ public class PluginEntry : INotifyPropertyChanged
         set { _isActive = value; Notify(); }
     }
 
-    public PluginEntry(IPanelPlugin plugin, bool isActive)
+    public PluginEntry(IPlugin plugin, bool isActive)
     {
         Plugin = plugin;
         _isActive = isActive;
@@ -49,10 +58,10 @@ public class PluginManagerViewModel : INotifyPropertyChanged
 
     public bool HasSelection => _selectedPlugin is not null;
 
-    public void Refresh(IReadOnlyList<IPanelPlugin> loadedPlugins, IPanelPlugin? activePlugin)
+    public void Refresh(IReadOnlyList<IPlugin> allPlugins, IPanelPlugin? activePlugin)
     {
         Plugins.Clear();
-        foreach (var plugin in loadedPlugins)
+        foreach (var plugin in allPlugins)
         {
             Plugins.Add(new PluginEntry(plugin, plugin.Id == activePlugin?.Id));
         }

--- a/src/SharpFM/PluginManager/PluginManagerWindow.axaml.cs
+++ b/src/SharpFM/PluginManager/PluginManagerWindow.axaml.cs
@@ -37,7 +37,7 @@ public partial class PluginManagerWindow : Window
         _pluginService = pluginService;
         _host = host;
         _mainVm = mainVm;
-        _viewModel.Refresh(pluginService.LoadedPlugins, mainVm.ActivePlugin);
+        _viewModel.Refresh(pluginService.AllPlugins, mainVm.ActivePlugin);
     }
 
     private async void OnInstall(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -59,8 +59,9 @@ public partial class PluginManagerWindow : Window
         var newPlugins = _pluginService.InstallPlugin(path, _host);
         if (newPlugins.Count > 0)
         {
-            _mainVm.PanelPlugins = _pluginService.LoadedPlugins;
-            _viewModel.Refresh(_pluginService.LoadedPlugins, _mainVm.ActivePlugin);
+            _mainVm.PanelPlugins = _pluginService.PanelPlugins;
+            _mainVm.TransformPlugins = _pluginService.TransformPlugins;
+            _viewModel.Refresh(_pluginService.AllPlugins, _mainVm.ActivePlugin);
         }
     }
 
@@ -71,12 +72,13 @@ public partial class PluginManagerWindow : Window
         var entry = _viewModel.SelectedPlugin;
         if (entry is null) return;
 
-        // Deactivate if this is the active plugin
-        if (_mainVm.ActivePlugin?.Id == entry.Id)
-            _mainVm.TogglePluginPanel(entry.Plugin);
+        // Deactivate if this is the active panel plugin
+        if (entry.Plugin is IPanelPlugin panelPlugin && _mainVm.ActivePlugin?.Id == entry.Id)
+            _mainVm.TogglePluginPanel(panelPlugin);
 
         _pluginService.UninstallPlugin(entry.Plugin);
-        _mainVm.PanelPlugins = _pluginService.LoadedPlugins;
-        _viewModel.Refresh(_pluginService.LoadedPlugins, _mainVm.ActivePlugin);
+        _mainVm.PanelPlugins = _pluginService.PanelPlugins;
+        _mainVm.TransformPlugins = _pluginService.TransformPlugins;
+        _viewModel.Refresh(_pluginService.AllPlugins, _mainVm.ActivePlugin);
     }
 }

--- a/src/SharpFM/Services/PluginHost.cs
+++ b/src/SharpFM/Services/PluginHost.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using SharpFM.Plugin;
 using SharpFM.ViewModels;
 
@@ -33,6 +35,9 @@ public class PluginHost : IPluginHost
 
         _trackedClip = _viewModel.SelectedClip;
         Subscribe(_trackedClip);
+
+        _viewModel.FileMakerClips.CollectionChanged += (_, _) =>
+            ClipCollectionChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public ClipInfo? SelectedClip
@@ -47,6 +52,14 @@ public class PluginHost : IPluginHost
 
     public event EventHandler<ClipInfo?>? SelectedClipChanged;
     public event EventHandler<ClipContentChangedArgs>? ClipContentChanged;
+    public event EventHandler? ClipCollectionChanged;
+
+    public IReadOnlyList<ClipInfo> AllClips =>
+        _viewModel.FileMakerClips
+            .Select(c => new ClipInfo(c.Name, c.ClipType, c.ClipXml))
+            .ToList();
+
+    public void ShowStatus(string message) => _viewModel.StatusMessage = message;
 
     public void UpdateSelectedClipXml(string xml, string originPluginId)
     {

--- a/src/SharpFM/Services/PluginService.cs
+++ b/src/SharpFM/Services/PluginService.cs
@@ -10,14 +10,35 @@ using SharpFM.Plugin;
 namespace SharpFM.Services;
 
 /// <summary>
-/// Discovers, loads, and manages <see cref="IPanelPlugin"/> implementations from the plugins/ directory.
+/// Discovers, loads, and manages plugin implementations from the plugins/ directory.
+/// Supports all plugin types: panel, event, persistence, and transform.
 /// </summary>
 public class PluginService
 {
     private readonly ILogger _logger;
-    private readonly List<IPanelPlugin> _loadedPlugins = [];
+    private readonly List<IPanelPlugin> _panelPlugins = [];
+    private readonly List<IEventPlugin> _eventPlugins = [];
+    private readonly List<IPersistencePlugin> _persistencePlugins = [];
+    private readonly List<IClipTransformPlugin> _transformPlugins = [];
 
-    public IReadOnlyList<IPanelPlugin> LoadedPlugins => _loadedPlugins;
+    /// <summary>Panel plugins that provide sidebar UI.</summary>
+    public IReadOnlyList<IPanelPlugin> PanelPlugins => _panelPlugins;
+
+    /// <summary>Headless event handler plugins.</summary>
+    public IReadOnlyList<IEventPlugin> EventPlugins => _eventPlugins;
+
+    /// <summary>Storage backend plugins.</summary>
+    public IReadOnlyList<IPersistencePlugin> PersistencePlugins => _persistencePlugins;
+
+    /// <summary>Clip transform plugins for import/export pipeline.</summary>
+    public IReadOnlyList<IClipTransformPlugin> TransformPlugins => _transformPlugins;
+
+    /// <summary>All loaded plugins across all types.</summary>
+    public IReadOnlyList<IPlugin> AllPlugins =>
+        [.. _panelPlugins, .. _eventPlugins, .. _persistencePlugins, .. _transformPlugins];
+
+    /// <summary>Backwards compat: returns panel plugins only.</summary>
+    public IReadOnlyList<IPanelPlugin> LoadedPlugins => _panelPlugins;
 
     public string PluginsDirectory { get; }
 
@@ -52,14 +73,17 @@ public class PluginService
             }
         }
 
-        _logger.LogInformation("Loaded {Count} plugin(s).", _loadedPlugins.Count);
+        _logger.LogInformation(
+            "Loaded {Count} plugin(s): {Panel} panel, {Event} event, {Persistence} persistence, {Transform} transform.",
+            AllPlugins.Count, _panelPlugins.Count, _eventPlugins.Count,
+            _persistencePlugins.Count, _transformPlugins.Count);
     }
 
     /// <summary>
     /// Copy a plugin DLL into the plugins directory and load it.
-    /// Returns the loaded plugin(s), or empty if it failed or contained no plugins.
+    /// Returns all newly loaded plugins, or empty if it failed or contained none.
     /// </summary>
-    public IReadOnlyList<IPanelPlugin> InstallPlugin(string sourceDllPath, IPluginHost host)
+    public IReadOnlyList<IPlugin> InstallPlugin(string sourceDllPath, IPluginHost host)
     {
         Directory.CreateDirectory(PluginsDirectory);
         var fileName = Path.GetFileName(sourceDllPath);
@@ -73,7 +97,7 @@ public class PluginService
         File.Copy(sourceDllPath, destPath, overwrite: true);
         _logger.LogInformation("Copied plugin to {Path}.", destPath);
 
-        var before = _loadedPlugins.Count;
+        var beforeCount = AllPlugins.Count;
         try
         {
             LoadPluginAssembly(destPath, host);
@@ -84,14 +108,14 @@ public class PluginService
             return [];
         }
 
-        return _loadedPlugins.Skip(before).ToList();
+        return AllPlugins.Skip(beforeCount).ToList();
     }
 
     /// <summary>
     /// Remove a plugin DLL from the plugins directory.
     /// The plugin remains in memory until the app restarts.
     /// </summary>
-    public bool UninstallPlugin(IPanelPlugin plugin)
+    public bool UninstallPlugin(IPlugin plugin)
     {
         var dllPath = FindPluginDll(plugin);
         if (dllPath is null)
@@ -103,7 +127,7 @@ public class PluginService
         try
         {
             plugin.Dispose();
-            _loadedPlugins.Remove(plugin);
+            RemoveFromTypedList(plugin);
             File.Delete(dllPath);
             _logger.LogInformation("Uninstalled plugin {Id} from {Path}.", plugin.Id, dllPath);
             return true;
@@ -126,7 +150,7 @@ public class PluginService
         return Directory.EnumerateFiles(PluginsDirectory, "*.dll").ToList();
     }
 
-    private string? FindPluginDll(IPanelPlugin plugin)
+    private string? FindPluginDll(IPlugin plugin)
     {
         var assembly = plugin.GetType().Assembly;
         var location = assembly.Location;
@@ -139,21 +163,53 @@ public class PluginService
         return File.Exists(candidate) ? candidate : null;
     }
 
+    private void RemoveFromTypedList(IPlugin plugin)
+    {
+        switch (plugin)
+        {
+            case IPanelPlugin p: _panelPlugins.Remove(p); break;
+            case IEventPlugin p: _eventPlugins.Remove(p); break;
+            case IPersistencePlugin p: _persistencePlugins.Remove(p); break;
+            case IClipTransformPlugin p: _transformPlugins.Remove(p); break;
+        }
+    }
+
     private void LoadPluginAssembly(string dllPath, IPluginHost host)
     {
         var context = new AssemblyLoadContext(Path.GetFileNameWithoutExtension(dllPath), isCollectible: false);
         var assembly = context.LoadFromAssemblyPath(Path.GetFullPath(dllPath));
 
-        var pluginTypes = assembly.GetTypes()
-            .Where(t => typeof(IPanelPlugin).IsAssignableFrom(t) && t is { IsAbstract: false, IsInterface: false });
+        var candidateTypes = assembly.GetTypes()
+            .Where(t => typeof(IPlugin).IsAssignableFrom(t) && t is { IsAbstract: false, IsInterface: false });
 
-        foreach (var type in pluginTypes)
+        foreach (var type in candidateTypes)
         {
-            if (Activator.CreateInstance(type) is not IPanelPlugin plugin) continue;
+            if (Activator.CreateInstance(type) is not IPlugin plugin) continue;
 
             plugin.Initialize(host);
-            _loadedPlugins.Add(plugin);
-            _logger.LogInformation("Loaded plugin: {Id} ({DisplayName})", plugin.Id, plugin.DisplayName);
+
+            switch (plugin)
+            {
+                case IPanelPlugin p:
+                    _panelPlugins.Add(p);
+                    break;
+                case IEventPlugin p:
+                    _eventPlugins.Add(p);
+                    break;
+                case IPersistencePlugin p:
+                    _persistencePlugins.Add(p);
+                    break;
+                case IClipTransformPlugin p:
+                    _transformPlugins.Add(p);
+                    break;
+                default:
+                    _logger.LogWarning("Plugin {Id} implements IPlugin but no known subtype, skipping.", plugin.Id);
+                    plugin.Dispose();
+                    continue;
+            }
+
+            _logger.LogInformation("Loaded {Type} plugin: {Id} ({DisplayName})",
+                plugin.GetType().BaseType?.Name ?? plugin.GetType().Name, plugin.Id, plugin.DisplayName);
         }
     }
 }

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -23,6 +23,7 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
     private readonly IClipboardService _clipboard;
     private readonly IFolderService _folderService;
     private readonly DispatcherTimer _statusTimer;
+    private IClipRepository _repository;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -63,26 +64,35 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
 
         FilteredClips = [];
 
-        LoadClips(CurrentPath);
+        _repository = new ClipRepository(_currentPath);
+        LoadClipsFromRepository();
     }
 
-    private void LoadClips(string pathToLoad)
+    public IClipRepository ActiveRepository => _repository;
+
+    private void LoadClipsFromRepository()
     {
-        var clipContext = new ClipRepository(pathToLoad);
-        clipContext.LoadClips();
+        var clips = _repository.LoadClipsAsync().GetAwaiter().GetResult();
 
         FileMakerClips.Clear();
 
-        foreach (var clip in clipContext.Clips)
+        foreach (var clip in clips)
         {
             FileMakerClips.Add(new ClipViewModel(
-                    new FileMakerClip(
-                        clip.ClipName,
-                        clip.ClipType,
-                        clip.ClipXml
-                    )
-                )
-            );
+                new FileMakerClip(clip.Name, clip.ClipType, clip.Xml)));
+        }
+    }
+
+    private async Task LoadClipsFromRepositoryAsync()
+    {
+        var clips = await _repository.LoadClipsAsync();
+
+        FileMakerClips.Clear();
+
+        foreach (var clip in clips)
+        {
+            FileMakerClips.Add(new ClipViewModel(
+                new FileMakerClip(clip.Name, clip.ClipType, clip.Xml)));
         }
     }
 
@@ -91,7 +101,8 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         try
         {
             CurrentPath = await _folderService.GetFolderAsync();
-            LoadClips(CurrentPath);
+            _repository = new ClipRepository(CurrentPath);
+            await LoadClipsFromRepositoryAsync();
             ShowStatus($"Opened {CurrentPath}");
         }
         catch (Exception e)
@@ -101,58 +112,39 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
-    public void SaveClipsStorage()
+    public async Task SwitchRepository(IClipRepository repository)
+    {
+        _repository = repository;
+        CurrentPath = repository.CurrentLocation;
+        await LoadClipsFromRepositoryAsync();
+        ShowStatus($"Switched to {repository.ProviderName}: {repository.CurrentLocation}");
+    }
+
+    public async Task SaveClipsStorageAsync()
     {
         try
         {
-            var clipContext = new ClipRepository(CurrentPath);
-            var fsClips = clipContext.Clips.ToList();
-
             foreach (var clip in FileMakerClips)
-            {
-                // Sync model to XML before saving
                 clip.SyncModelFromEditor();
 
-                var dbClip = fsClips.FirstOrDefault(dbc => dbc.ClipName == clip.Name);
+            var clipData = FileMakerClips
+                .Select(c => new ClipData(c.Name, c.ClipType, c.ClipXml))
+                .ToList();
 
-                if (dbClip is not null)
-                {
-                    dbClip.ClipType = clip.ClipType;
-                    dbClip.ClipXml = clip.ClipXml;
-                }
-                else
-                {
-                    clipContext.Clips.Add(new Clip()
-                    {
-                        ClipName = clip.Name,
-                        ClipType = clip.ClipType,
-                        ClipXml = clip.ClipXml
-                    });
-                }
-            }
+            await _repository.SaveClipsAsync(clipData);
 
-            clipContext.SaveChanges();
-
-            // Remove files for clips that no longer exist in memory
-            var activeNames = new HashSet<string>(
-                FileMakerClips.Select(c => $"{c.Name}.{c.ClipType}"),
-                StringComparer.OrdinalIgnoreCase);
-
-            foreach (var file in Directory.EnumerateFiles(CurrentPath))
-            {
-                if (!activeNames.Contains(Path.GetFileName(file)))
-                {
-                    File.Delete(file);
-                }
-            }
-
-            ShowStatus($"Saved {FileMakerClips.Count} clip(s) to {CurrentPath}");
+            ShowStatus($"Saved {clipData.Count} clip(s) to {_repository.CurrentLocation}");
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error saving clips.");
             ShowStatus("Error saving clips", isError: true);
         }
+    }
+
+    public void SaveClipsStorage()
+    {
+        SaveClipsStorageAsync().GetAwaiter().GetResult();
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Bound to Xaml Button, throws when static.")]

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -404,6 +404,20 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+    private IReadOnlyList<IClipTransformPlugin> _transformPlugins = [];
+    public IReadOnlyList<IClipTransformPlugin> TransformPlugins
+    {
+        get => _transformPlugins;
+        set { _transformPlugins = value; NotifyPropertyChanged(); }
+    }
+
+    private IReadOnlyList<IClipRepository> _availableRepositories = [];
+    public IReadOnlyList<IClipRepository> AvailableRepositories
+    {
+        get => _availableRepositories;
+        set { _availableRepositories = value; NotifyPropertyChanged(); }
+    }
+
     public void TogglePluginPanel(IPanelPlugin plugin)
     {
         if (_activePlugin?.Id == plugin.Id)

--- a/tests/SharpFM.Plugin.Tests/PluginHostTests.cs
+++ b/tests/SharpFM.Plugin.Tests/PluginHostTests.cs
@@ -143,4 +143,43 @@ public class PluginHostTests
         Assert.NotNull(received);
         Assert.Equal("New Script", received!.Name);
     }
+
+    // --- New IPluginHost members ---
+
+    [Fact]
+    public void AllClips_ReturnsAllLoadedClips()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm);
+
+        var baseline = host.AllClips.Count;
+        vm.NewScriptCommand();
+        vm.NewTableCommand();
+
+        Assert.Equal(baseline + 2, host.AllClips.Count);
+    }
+
+    [Fact]
+    public void ClipCollectionChanged_Fires_WhenClipAdded()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm);
+        var fired = false;
+        host.ClipCollectionChanged += (_, _) => fired = true;
+
+        vm.NewScriptCommand();
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void ShowStatus_SetsViewModelStatus()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm);
+
+        host.ShowStatus("Plugin says hello");
+
+        Assert.Equal("Plugin says hello", vm.StatusMessage);
+    }
 }

--- a/tests/SharpFM.Plugin.Tests/PluginInterfaceTests.cs
+++ b/tests/SharpFM.Plugin.Tests/PluginInterfaceTests.cs
@@ -1,0 +1,91 @@
+using SharpFM.Plugin;
+using Xunit;
+
+namespace SharpFM.Plugin.Tests;
+
+public class PluginInterfaceTests
+{
+    // --- IPlugin hierarchy ---
+
+    [Fact]
+    public void IPanelPlugin_Extends_IPlugin()
+    {
+        Assert.True(typeof(IPlugin).IsAssignableFrom(typeof(IPanelPlugin)));
+    }
+
+    [Fact]
+    public void IEventPlugin_Extends_IPlugin()
+    {
+        Assert.True(typeof(IPlugin).IsAssignableFrom(typeof(IEventPlugin)));
+    }
+
+    [Fact]
+    public void IPersistencePlugin_Extends_IPlugin()
+    {
+        Assert.True(typeof(IPlugin).IsAssignableFrom(typeof(IPersistencePlugin)));
+    }
+
+    [Fact]
+    public void IClipTransformPlugin_Extends_IPlugin()
+    {
+        Assert.True(typeof(IPlugin).IsAssignableFrom(typeof(IClipTransformPlugin)));
+    }
+
+    [Fact]
+    public void IPanelPlugin_Extends_IDisposable()
+    {
+        Assert.True(typeof(IDisposable).IsAssignableFrom(typeof(IPanelPlugin)));
+    }
+
+    [Fact]
+    public void IEventPlugin_Extends_IDisposable()
+    {
+        Assert.True(typeof(IDisposable).IsAssignableFrom(typeof(IEventPlugin)));
+    }
+
+    // --- ClipData record ---
+
+    [Fact]
+    public void ClipData_RecordEquality()
+    {
+        var a = new ClipData("Test", "Mac-XMSS", "<xml/>");
+        var b = new ClipData("Test", "Mac-XMSS", "<xml/>");
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void ClipData_Properties()
+    {
+        var clip = new ClipData("MyClip", "Mac-XMTB", "<data/>");
+        Assert.Equal("MyClip", clip.Name);
+        Assert.Equal("Mac-XMTB", clip.ClipType);
+        Assert.Equal("<data/>", clip.Xml);
+    }
+
+    // --- IPluginHost new members on MockPluginHost ---
+
+    [Fact]
+    public void MockPluginHost_AllClips_DefaultsToEmpty()
+    {
+        var host = new MockPluginHost();
+        Assert.Empty(host.AllClips);
+    }
+
+    [Fact]
+    public void MockPluginHost_ShowStatus_RecordsMessage()
+    {
+        var host = new MockPluginHost();
+        host.ShowStatus("test message");
+        Assert.Equal("test message", host.LastStatus);
+    }
+
+    [Fact]
+    public void MockPluginHost_ClipCollectionChanged_Fires()
+    {
+        var host = new MockPluginHost();
+        var fired = false;
+        host.ClipCollectionChanged += (_, _) => fired = true;
+        host.RaiseCollectionChanged();
+        Assert.True(fired);
+    }
+}

--- a/tests/SharpFM.Plugin.Tests/PluginManagerViewModelTests.cs
+++ b/tests/SharpFM.Plugin.Tests/PluginManagerViewModelTests.cs
@@ -23,7 +23,7 @@ public class PluginManagerViewModelTests
     public void Refresh_PopulatesPlugins()
     {
         var vm = new PluginManagerViewModel();
-        var plugins = new List<IPanelPlugin> { new StubPlugin() };
+        var plugins = new List<IPlugin> { new StubPlugin() };
 
         vm.Refresh(plugins, activePlugin: null);
 
@@ -37,7 +37,7 @@ public class PluginManagerViewModelTests
     {
         var vm = new PluginManagerViewModel();
         var plugin = new StubPlugin { Id = "active-one" };
-        var plugins = new List<IPanelPlugin> { plugin, new StubPlugin { Id = "other" } };
+        var plugins = new List<IPlugin> { plugin, new StubPlugin { Id = "other" } };
 
         vm.Refresh(plugins, activePlugin: plugin);
 
@@ -49,11 +49,18 @@ public class PluginManagerViewModelTests
     public void Refresh_ClearsPreviousEntries()
     {
         var vm = new PluginManagerViewModel();
-        vm.Refresh(new List<IPanelPlugin> { new StubPlugin() }, null);
+        vm.Refresh(new List<IPlugin> { new StubPlugin() }, null);
         Assert.Single(vm.Plugins);
 
-        vm.Refresh(new List<IPanelPlugin>(), null);
+        vm.Refresh(new List<IPlugin>(), null);
         Assert.Empty(vm.Plugins);
+    }
+
+    [Fact]
+    public void PluginEntry_PluginType_Panel()
+    {
+        var entry = new PluginEntry(new StubPlugin(), false);
+        Assert.Equal("Panel", entry.PluginType);
     }
 
     [Fact]

--- a/tests/SharpFM.Plugin.Tests/PluginServiceTests.cs
+++ b/tests/SharpFM.Plugin.Tests/PluginServiceTests.cs
@@ -108,6 +108,26 @@ public class PluginServiceTests
     }
 
     [Fact]
+    public void AllPlugins_AggregatesAllTypes()
+    {
+        var service = CreateService("/tmp/nonexistent-" + Guid.NewGuid());
+        // No plugins loaded, but verify the property returns empty aggregate
+        Assert.Empty(service.AllPlugins);
+        Assert.Empty(service.PanelPlugins);
+        Assert.Empty(service.EventPlugins);
+        Assert.Empty(service.PersistencePlugins);
+        Assert.Empty(service.TransformPlugins);
+    }
+
+    [Fact]
+    public void LoadedPlugins_ReturnsPanelPlugins()
+    {
+        var service = CreateService("/tmp/nonexistent-" + Guid.NewGuid());
+        // LoadedPlugins is a backwards-compat alias for PanelPlugins
+        Assert.Same(service.PanelPlugins, service.LoadedPlugins);
+    }
+
+    [Fact]
     public void InstallPlugin_OverwritesExisting()
     {
         var pluginsDir = Path.Combine(Path.GetTempPath(), $"sharpfm-test-{Guid.NewGuid()}");

--- a/tests/SharpFM.Plugin.Tests/PluginServiceTests.cs
+++ b/tests/SharpFM.Plugin.Tests/PluginServiceTests.cs
@@ -10,12 +10,17 @@ namespace SharpFM.Plugin.Tests;
 public class MockPluginHost : IPluginHost
 {
     public ClipInfo? SelectedClip { get; set; }
+    public IReadOnlyList<ClipInfo> AllClips { get; set; } = [];
     public event EventHandler<ClipInfo?>? SelectedClipChanged;
     public event EventHandler<ClipContentChangedArgs>? ClipContentChanged;
+    public event EventHandler? ClipCollectionChanged;
     public void UpdateSelectedClipXml(string xml, string originPluginId) { }
     public ClipInfo? RefreshSelectedClip() => SelectedClip;
+    public void ShowStatus(string message) { LastStatus = message; }
+    public string? LastStatus { get; private set; }
     public void RaiseChanged(ClipInfo? clip) => SelectedClipChanged?.Invoke(this, clip);
     public void RaiseContentChanged(ClipContentChangedArgs args) => ClipContentChanged?.Invoke(this, args);
+    public void RaiseCollectionChanged() => ClipCollectionChanged?.Invoke(this, EventArgs.Empty);
 }
 
 public class PluginServiceTests

--- a/tests/SharpFM.Plugin.Tests/XmlViewerPluginTests.cs
+++ b/tests/SharpFM.Plugin.Tests/XmlViewerPluginTests.cs
@@ -133,10 +133,12 @@ public class XmlViewerPluginTests
 public class TrackingPluginHost : IPluginHost
 {
     public ClipInfo? SelectedClip { get; set; }
+    public IReadOnlyList<ClipInfo> AllClips { get; set; } = [];
     public string? LastUpdatedXml { get; private set; }
     public string? LastOriginPluginId { get; private set; }
     public event EventHandler<ClipInfo?>? SelectedClipChanged;
     public event EventHandler<ClipContentChangedArgs>? ClipContentChanged;
+    public event EventHandler? ClipCollectionChanged;
 
     public void UpdateSelectedClipXml(string xml, string originPluginId)
     {
@@ -145,6 +147,7 @@ public class TrackingPluginHost : IPluginHost
     }
 
     public ClipInfo? RefreshSelectedClip() => SelectedClip;
+    public void ShowStatus(string message) { }
     public void RaiseChanged(ClipInfo? clip) => SelectedClipChanged?.Invoke(this, clip);
     public void RaiseContentChanged(ClipContentChangedArgs args) => ClipContentChanged?.Invoke(this, args);
 }

--- a/tests/SharpFM.Tests/Models/ClipRepositoryTests.cs
+++ b/tests/SharpFM.Tests/Models/ClipRepositoryTests.cs
@@ -1,0 +1,174 @@
+using System.IO;
+using System.Linq;
+using SharpFM.Models;
+using SharpFM.Plugin;
+using Xunit;
+
+namespace SharpFM.Tests.Models;
+
+public class ClipRepositoryTests
+{
+    private static string CreateTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"sharpfm-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void ProviderName_IsLocalFiles()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            Assert.Equal("Local Files", repo.ProviderName);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void CurrentLocation_ReturnsPath()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            Assert.Equal(dir, repo.CurrentLocation);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void SupportsLocationPicker_IsFalse()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            Assert.False(repo.SupportsLocationPicker);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task PickLocationAsync_ReturnsNull()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            Assert.Null(await repo.PickLocationAsync());
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void Constructor_CreatesDirectory_IfMissing()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"sharpfm-test-{Guid.NewGuid()}");
+        try
+        {
+            Assert.False(Directory.Exists(dir));
+            _ = new ClipRepository(dir);
+            Assert.True(Directory.Exists(dir));
+        }
+        finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task LoadClipsAsync_ReturnsEmpty_ForEmptyDir()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            var clips = await repo.LoadClipsAsync();
+            Assert.Empty(clips);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task LoadClipsAsync_ReadsClipFiles()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "MyScript.Mac-XMSS"), "<xml>script</xml>");
+            File.WriteAllText(Path.Combine(dir, "MyTable.Mac-XMTB"), "<xml>table</xml>");
+
+            var repo = new ClipRepository(dir);
+            var clips = await repo.LoadClipsAsync();
+
+            Assert.Equal(2, clips.Count);
+            Assert.Contains(clips, c => c.Name == "MyScript" && c.ClipType == "Mac-XMSS");
+            Assert.Contains(clips, c => c.Name == "MyTable" && c.ClipType == "Mac-XMTB");
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveClipsAsync_WritesFiles()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            var clips = new List<ClipData>
+            {
+                new("Script1", "Mac-XMSS", "<xml>1</xml>"),
+                new("Table1", "Mac-XMTB", "<xml>2</xml>")
+            };
+
+            await repo.SaveClipsAsync(clips);
+
+            Assert.True(File.Exists(Path.Combine(dir, "Script1.Mac-XMSS")));
+            Assert.True(File.Exists(Path.Combine(dir, "Table1.Mac-XMTB")));
+            Assert.Equal("<xml>1</xml>", File.ReadAllText(Path.Combine(dir, "Script1.Mac-XMSS")));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveClipsAsync_DeletesOrphanedFiles()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Old.Mac-XMSS"), "<old/>");
+            File.WriteAllText(Path.Combine(dir, "Keep.Mac-XMSS"), "<keep/>");
+
+            var repo = new ClipRepository(dir);
+            await repo.SaveClipsAsync([new("Keep", "Mac-XMSS", "<updated/>")]);
+
+            Assert.False(File.Exists(Path.Combine(dir, "Old.Mac-XMSS")));
+            Assert.True(File.Exists(Path.Combine(dir, "Keep.Mac-XMSS")));
+            Assert.Equal("<updated/>", File.ReadAllText(Path.Combine(dir, "Keep.Mac-XMSS")));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task Roundtrip_LoadSaveLoad()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            var original = new List<ClipData>
+            {
+                new("Script", "Mac-XMSS", "<xml>data</xml>")
+            };
+
+            await repo.SaveClipsAsync(original);
+            var loaded = await repo.LoadClipsAsync();
+
+            Assert.Single(loaded);
+            Assert.Equal("Script", loaded[0].Name);
+            Assert.Equal("Mac-XMSS", loaded[0].ClipType);
+            Assert.Equal("<xml>data</xml>", loaded[0].Xml);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `IPlugin` base interface with shared metadata and lifecycle for all plugin types
- Add `IEventPlugin` — headless event handlers that react to host events with no UI
- Add `IPersistencePlugin` + `IClipRepository` — pluggable storage backends (cloud API, database, etc.)
- Add `IClipTransformPlugin` — modify clip XML during import/export operations
- Refactor `ClipRepository` to implement `IClipRepository` with async methods
- Refactor `MainWindowViewModel` to use `IClipRepository` abstraction instead of concrete `ClipRepository`
- Expand `PluginService` for multi-type plugin discovery and categorization
- Generalize Plugin Manager UI to display all plugin types with type labels
- Extend `IPluginHost` with `AllClips`, `ClipCollectionChanged`, and `ShowStatus`
- Add plugin development documentation in `docs/plugins/`