### PR TITLE
feat: object model as source of truth with save/dirty editors

### DIFF
--- a/docs/design/object-model-as-truth.md
+++ b/docs/design/object-model-as-truth.md
@@ -1,0 +1,261 @@
+# Design: Object Model as Source of Truth
+
+## Problem
+
+SharpFM currently treats **display text as canonical** during script editing. The roundtrip is:
+
+```
+XML → display text → [user edits text] → re-parse to model → XML
+```
+
+This works for the text editor but makes programmatic access (agents via MCP, plugins, structured editors) fragile — they'd need to manipulate bracket syntax and parse display text. The object model (`FmScript`, `ScriptStep`, `StepParamValue`) already exists but is derived, not authoritative.
+
+## Goal
+
+Make the **object model the single source of truth** for all clip content. All editors, agents, and plugins read from and write to the model. Text and XML become projections (renderings) of the model, not the other way around.
+
+```
+                    ┌─── Script Text Editor (render/parse)
+                    │
+Object Model ───────┼─── XML Editor (render/parse)
+   (truth)          │
+                    ├─── Table/Field DataGrid (render/bind)
+                    │
+                    ├─── Agent / MCP (structured API)
+                    │
+                    └─── Plugin API (IPluginHost)
+```
+
+## Scope
+
+This design covers:
+- What the object model owns and how it's mutated
+- The contract between the model and its editors/consumers
+- How this integrates with the existing plugin system
+- How MCP/agent access would work against this model
+
+This design does NOT cover:
+- Specific MCP tool definitions
+- UI changes to switch between editors
+- Detailed implementation of each editor adapter
+
+---
+
+## Core Concepts
+
+### The Clip Model
+
+A clip is already represented by `FileMakerClip` (name, format, XML) wrapped in `ClipViewModel` (editor state, change detection). The model-as-truth change deepens this: instead of `ClipViewModel` holding a text document that IS the state, it holds a **typed model** that renderers project into text/grid/XML.
+
+For script clips, the typed model is `FmScript` (a list of `ScriptStep` objects).
+For table clips, the typed model is `FmTable` (a list of `FmField` objects).
+For other clip types, the model is the raw XML string (unchanged from today).
+
+### Mutation Paths
+
+Every change to clip content goes through the model:
+
+| Source | How it mutates | Example |
+|--------|---------------|---------|
+| Script text editor | Parse changed text → update `FmScript.Steps` | User types a new line |
+| XML editor | Parse XML → rebuild model | User edits raw XML |
+| Table DataGrid | Direct property mutation on `FmField` | User changes field type |
+| Agent (MCP) | Structured API call → model mutation | "Add If step at index 3" |
+| Plugin | `IPluginHost.UpdateSelectedClipXml()` or future model API | Plugin reformats XML |
+
+### Rendering (Model → View)
+
+After any mutation, all **other** views re-render from the model:
+
+| View | Renders from |
+|------|-------------|
+| Script text editor | `FmScript.ToDisplayText()` |
+| XML editor | `FmScript.ToXml()` (or raw XML for non-script clips) |
+| Table DataGrid | Binding to `FmTable.Fields` collection |
+| Plugin panels | `ClipContentChanged` event with `ClipInfo` snapshot |
+
+The view that **caused** the mutation does NOT re-render from the model. It already has the user's state. This is the "origin tagging" pattern already used in the plugin system.
+
+---
+
+## Editor Contract
+
+### Saved/Unsaved State
+
+Each editor maintains a **local buffer** that is either **clean** (matches the model) or **dirty** (user has unsaved changes). The model only changes when the user explicitly **saves** or when an external mutation occurs.
+
+- **Clean**: editor content matches the model. No risk of data loss.
+- **Dirty**: editor has unsaved changes that haven't been flushed to the model.
+
+This is NOT a live/real-time sync. Edits are batched — the user works freely in their editor and saves when ready. The model updates discretely, not on every keystroke.
+
+### Save (User Action)
+
+When the user saves (Ctrl+S, button, or editor-specific trigger):
+
+1. Editor **parses** its local state into the model (`FmScript.FromDisplayText()` or `FmScript.FromXml()`).
+2. Model **replaces** its state with the parsed result.
+3. Model fires `StepsChanged` event.
+4. Other views **re-render** from the updated model.
+5. The saving editor is marked **clean**.
+
+### External Mutation (Agent, Plugin, Other Editor)
+
+When the model changes from any external source:
+
+1. Model fires `StepsChanged` event with origin tag.
+2. All editors **re-render** from the model, replacing their local buffer.
+3. **Unsaved changes in the active editor are lost.** This is acceptable — external mutations are discrete operations (agent commands, plugin actions), not continuous collaborative edits. The user can see the change and continue editing.
+4. **Cursor position is preserved.** After re-rendering, restore the cursor offset (clamped to the new text length). This avoids disorienting the user.
+5. All editors are marked **clean** after re-render.
+
+### Dirty State and External Mutations
+
+If an editor is dirty and an external mutation arrives, the editor re-renders and the unsaved changes are lost. This is the explicit contract: **save early if you want to keep your work.** The UI should indicate dirty state (e.g., dot on tab, modified indicator) so the user knows they have unsaved changes.
+
+Future consideration: we could prompt "You have unsaved changes — discard?" before applying external mutations. But for the initial implementation, the simpler model (external wins) is sufficient.
+
+### Editor Transitions
+
+When the user switches from editor A to editor B:
+
+1. If editor A is **dirty**, prompt to save or discard (or auto-save — TBD).
+2. Editor B **renders** from the model.
+3. Editor B becomes the active editor, marked **clean**.
+
+### No Debounce Needed
+
+Since the model only changes on explicit save or external mutation, there's no need for debounced sync timers. The generation counter / debounce pattern currently in `ClipViewModel` can be removed in favor of this simpler contract.
+
+---
+
+## Model Mutation API
+
+The `FmScript` model needs a mutation API beyond the current factory methods. These operations are what editors, agents, and plugins would use:
+
+### Script Operations
+
+```
+AddStep(int index, ScriptStep step)
+RemoveStep(int index)
+MoveStep(int fromIndex, int toIndex)
+UpdateStep(int index, ScriptStep replacement)
+ReplaceSteps(IReadOnlyList<ScriptStep> steps)  // bulk: parse from text/XML
+```
+
+### Step-Level Operations
+
+```
+SetEnabled(bool enabled)
+SetParamValue(string paramName, string? value)
+```
+
+### Query Operations (for agents/plugins)
+
+```
+FindSteps(string stepName) → IReadOnlyList<(int index, ScriptStep step)>
+GetStep(int index) → ScriptStep
+StepCount → int
+```
+
+### Change Notification
+
+```
+event StepsChanged  // fired after any mutation, with change details
+```
+
+The `StepsChanged` event carries enough info for renderers to decide whether to do a full re-render or a targeted update (e.g., single step changed at index 5).
+
+---
+
+## Table/Field Model
+
+Tables already have a typed model (`FmTable` with `FmField` list). The same principles apply:
+
+- `FmTable` is the source of truth
+- DataGrid binds to `FmTable.Fields`
+- XML editor renders from `FmTable.ToXml()`
+- Agent/MCP can call `AddField()`, `RemoveField()`, `UpdateField()`
+
+The table model is already closer to this architecture than scripts are.
+
+---
+
+## Integration with Plugin System
+
+### Current: XML-level
+
+Plugins interact via `IPluginHost.UpdateSelectedClipXml(xml, originId)`. This stays as-is for backwards compatibility and for plugins that want to work with raw XML.
+
+### Future: Model-level (additive)
+
+Add model-aware methods to `IPluginHost`:
+
+```
+IFmScript? GetScriptModel()          // null if not a script clip
+IFmTable? GetTableModel()            // null if not a table clip
+void UpdateScriptModel(Action<IFmScript> mutation, string originId)
+void UpdateTableModel(Action<IFmTable> mutation, string originId)
+```
+
+The `Action<IFmScript>` pattern lets plugins make multiple mutations atomically — the model fires a single change event after the action completes.
+
+Plugins compiled against the old API still work (XML-level). New plugins can use the model API for structured access. The host translates between them: an XML push re-parses the model; a model mutation re-derives the XML for legacy listeners.
+
+### MCP Tools
+
+MCP tools would wrap the same model API:
+
+```
+sharpfm_script_add_step(index, step_name, params)
+sharpfm_script_remove_step(index)
+sharpfm_script_find_steps(step_name) → list of steps
+sharpfm_script_get_all_steps() → full script model
+sharpfm_table_add_field(name, type, ...)
+sharpfm_table_get_fields() → field list
+```
+
+These are thin wrappers over the mutation/query API on the model.
+
+---
+
+## Migration Path
+
+### Phase A — Model as hub for scripts
+
+1. `FmScript` gains mutation methods (`AddStep`, `RemoveStep`, etc.)
+2. `FmScript` gains `StepsChanged` event
+3. `ScriptClipEditor` refactored: text changes → parse → `ReplaceSteps()` on model; model changes → re-render text (unless self-originated)
+4. XML editor for scripts: XML changes → `FmScript.FromXml()` → `ReplaceSteps()`; model changes → `FmScript.ToXml()` → re-render XML
+5. All existing tests still pass — roundtrip behavior unchanged
+
+### Phase B — Model-level plugin/agent API
+
+6. Add `GetScriptModel()` / `UpdateScriptModel()` to `IPluginHost`
+7. Add MCP tool definitions that wrap the model API
+8. Origin tagging extended to model-level mutations
+
+### Phase C — Table model alignment
+
+9. Apply the same pattern to `FmTable` (already mostly there)
+10. `TableClipEditor` refactored to same hub pattern
+11. Add `GetTableModel()` / `UpdateTableModel()` to `IPluginHost`
+
+### Phase D — Typed step accessors
+
+12. Add convenience accessors on `ScriptStep` for common patterns:
+    - `GetCalculation()`, `GetFieldReference()`, `GetScriptReference()`
+    - `GetNamedParam(string label)` — typed wrapper over `ParamValues`
+13. These are additive — no breaking changes, just ergonomic API for agents/plugins
+
+---
+
+## What Doesn't Change
+
+- `FileMakerClip` still holds the XML string as the persistence format
+- `ClipRepository` / `IClipRepository` still loads/saves XML
+- `StepCatalog` / `StepDefinition` / `StepParam` unchanged
+- Handler registry unchanged (handlers render/serialize, they don't own state)
+- Plugin `IPluginHost.UpdateSelectedClipXml()` still works
+- Display text format (`Step [ param ; param ]`) unchanged
+- All existing tests pass at each phase

--- a/src/SharpFM/Editors/FallbackXmlEditor.cs
+++ b/src/SharpFM/Editors/FallbackXmlEditor.cs
@@ -1,5 +1,4 @@
 using System;
-using Avalonia.Threading;
 using AvaloniaEdit.Document;
 
 namespace SharpFM.Editors;
@@ -7,40 +6,64 @@ namespace SharpFM.Editors;
 /// <summary>
 /// Editor for clips with no specialized editor (layouts, unknown formats).
 /// The user edits the raw XML directly via a TextDocument.
+/// The saved XML string is the source of truth.
 /// </summary>
 public class FallbackXmlEditor : IClipEditor
 {
-    private readonly DispatcherTimer _debounceTimer;
+    private string _savedXml;
+    private bool _suppressDirty;
 
-    public event EventHandler? ContentChanged;
+    public event EventHandler? BecameDirty;
+    public event EventHandler? Saved;
 
     /// <summary>The TextDocument bound to the AvaloniaEdit XML editor.</summary>
     public TextDocument Document { get; }
 
+    public bool IsDirty { get; private set; }
     public bool IsPartial => false;
 
     public FallbackXmlEditor(string? xml)
     {
-        Document = new TextDocument(xml ?? "");
+        _savedXml = xml ?? "";
+        Document = new TextDocument(_savedXml);
 
-        _debounceTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
-        _debounceTimer.Tick += (_, _) =>
-        {
-            _debounceTimer.Stop();
-            ContentChanged?.Invoke(this, EventArgs.Empty);
-        };
-
-        Document.TextChanged += (_, _) =>
-        {
-            _debounceTimer.Stop();
-            _debounceTimer.Start();
-        };
+        Document.TextChanged += OnTextChanged;
     }
 
-    public string ToXml() => Document.Text;
+    private void OnTextChanged(object? sender, EventArgs e)
+    {
+        if (_suppressDirty) return;
+        if (!IsDirty)
+        {
+            IsDirty = true;
+            BecameDirty?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public bool Save()
+    {
+        _savedXml = Document.Text;
+        IsDirty = false;
+        Saved?.Invoke(this, EventArgs.Empty);
+        return true;
+    }
+
+    public string ToXml() => _savedXml;
 
     public void FromXml(string xml)
     {
-        Document.Text = xml;
+        _savedXml = xml;
+
+        _suppressDirty = true;
+        try
+        {
+            Document.Text = xml;
+        }
+        finally
+        {
+            _suppressDirty = false;
+        }
+
+        IsDirty = false;
     }
 }

--- a/src/SharpFM/Editors/FallbackXmlEditor.cs
+++ b/src/SharpFM/Editors/FallbackXmlEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Xml.Linq;
 using AvaloniaEdit.Document;
 
 namespace SharpFM.Editors;
@@ -6,7 +7,7 @@ namespace SharpFM.Editors;
 /// <summary>
 /// Editor for clips with no specialized editor (layouts, unknown formats).
 /// The user edits the raw XML directly via a TextDocument.
-/// The saved XML string is the source of truth.
+/// Save validates the XML before accepting it — invalid XML stays dirty.
 /// </summary>
 public class FallbackXmlEditor : IClipEditor
 {
@@ -20,7 +21,7 @@ public class FallbackXmlEditor : IClipEditor
     public TextDocument Document { get; }
 
     public bool IsDirty { get; private set; }
-    public bool IsPartial => false;
+    public bool IsPartial { get; private set; }
 
     public FallbackXmlEditor(string? xml)
     {
@@ -42,7 +43,21 @@ public class FallbackXmlEditor : IClipEditor
 
     public bool Save()
     {
-        _savedXml = Document.Text;
+        var text = Document.Text;
+
+        // Validate XML before accepting
+        try
+        {
+            XDocument.Parse(text);
+        }
+        catch
+        {
+            IsPartial = true;
+            return false;
+        }
+
+        _savedXml = text;
+        IsPartial = false;
         IsDirty = false;
         Saved?.Invoke(this, EventArgs.Empty);
         return true;
@@ -65,5 +80,6 @@ public class FallbackXmlEditor : IClipEditor
         }
 
         IsDirty = false;
+        IsPartial = false;
     }
 }

--- a/src/SharpFM/Editors/IClipEditor.cs
+++ b/src/SharpFM/Editors/IClipEditor.cs
@@ -6,28 +6,51 @@ namespace SharpFM.Editors;
 /// Abstraction for clip-type-specific editing. Each clip type provides an implementation
 /// that handles change detection, XML serialization, and reverse sync. ClipViewModel holds
 /// one IClipEditor and delegates all sync operations to it — no clip-type branching needed.
+///
+/// Editors follow a save/dirty model:
+/// - User edits make the editor dirty (local buffer diverges from model).
+/// - Save flushes the local buffer to the model (ToXml returns authoritative XML).
+/// - External mutations (FromXml) re-render from the model, clearing dirty state.
 /// </summary>
 public interface IClipEditor
 {
     /// <summary>
-    /// Fires when the user edits content in the structured editor.
-    /// Implementations should debounce this (e.g. 500ms) to avoid excessive events.
+    /// Fires when the editor transitions from clean to dirty (user made an edit).
+    /// Does NOT fire on every keystroke — only on the first change after a save or load.
     /// </summary>
-    event EventHandler? ContentChanged;
+    event EventHandler? BecameDirty;
 
     /// <summary>
-    /// Serialize the current editor state to XML.
+    /// Fires after a successful <see cref="Save"/>, indicating the model has been updated.
+    /// </summary>
+    event EventHandler? Saved;
+
+    /// <summary>
+    /// Whether the editor has unsaved changes (local buffer differs from model).
+    /// </summary>
+    bool IsDirty { get; }
+
+    /// <summary>
+    /// Flush the editor's local buffer to the model. After save, <see cref="IsDirty"/> is false
+    /// and <see cref="ToXml"/> returns the newly saved state.
+    /// Returns true if save succeeded, false if the editor content couldn't be parsed.
+    /// </summary>
+    bool Save();
+
+    /// <summary>
+    /// Serialize the current model state to XML. Returns the last saved state, not
+    /// the live editor buffer. Call <see cref="Save"/> first to flush pending edits.
     /// </summary>
     string ToXml();
 
     /// <summary>
-    /// Load XML into the editor (reverse sync from an external source like a plugin).
-    /// Implementations should diff/patch when possible to preserve UI state.
+    /// Load XML into the editor from an external source (plugin, agent, other editor).
+    /// Replaces the local buffer and model. Clears dirty state. Preserves cursor position.
     /// </summary>
     void FromXml(string xml);
 
     /// <summary>
-    /// True if the last <see cref="ToXml"/> produced output from an incomplete or errored parse.
+    /// True if the last <see cref="Save"/> produced output from an incomplete or errored parse.
     /// For example, a half-typed script step that can't fully round-trip.
     /// </summary>
     bool IsPartial { get; }

--- a/src/SharpFM/Editors/IClipEditor.cs
+++ b/src/SharpFM/Editors/IClipEditor.cs
@@ -31,9 +31,12 @@ public interface IClipEditor
     bool IsDirty { get; }
 
     /// <summary>
-    /// Flush the editor's local buffer to the model. After save, <see cref="IsDirty"/> is false
-    /// and <see cref="ToXml"/> returns the newly saved state.
-    /// Returns true if save succeeded, false if the editor content couldn't be parsed.
+    /// Flush the editor's local buffer to the model. Validates the content first.
+    /// On success: <see cref="IsDirty"/> becomes false, <see cref="IsPartial"/> becomes false,
+    /// <see cref="Saved"/> fires, and <see cref="ToXml"/> returns the newly saved state.
+    /// On failure (invalid content): returns false, <see cref="IsDirty"/> stays true,
+    /// <see cref="IsPartial"/> becomes true, <see cref="Saved"/> does NOT fire,
+    /// and <see cref="ToXml"/> continues to return the last valid state.
     /// </summary>
     bool Save();
 

--- a/src/SharpFM/Editors/ScriptClipEditor.cs
+++ b/src/SharpFM/Editors/ScriptClipEditor.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using AvaloniaEdit.Document;
 using SharpFM.Scripting;
 
@@ -6,11 +8,14 @@ namespace SharpFM.Editors;
 
 /// <summary>
 /// Editor for script clips (Mac-XMSS, Mac-XMSC). The FmScript model is the source of truth.
-/// The TextDocument is a projection that the user edits. Save parses text back into the model.
+/// The TextDocument is a projection that the user edits. Save parses text back into the model,
+/// merging with the existing model to preserve multi-line content (comments, calculations)
+/// that is only shown truncated in the text editor.
 /// </summary>
 public class ScriptClipEditor : IClipEditor
 {
     private FmScript _script;
+    private string[] _renderedLines;
     private bool _suppressDirty;
 
     public event EventHandler? BecameDirty;
@@ -28,7 +33,8 @@ public class ScriptClipEditor : IClipEditor
     public ScriptClipEditor(string? xml)
     {
         _script = FmScript.FromXml(xml ?? "");
-        Document = new TextDocument(_script.ToDisplayText());
+        _renderedLines = _script.ToDisplayLines();
+        Document = new TextDocument(string.Join("\n", _renderedLines));
 
         Document.TextChanged += OnTextChanged;
     }
@@ -47,7 +53,21 @@ public class ScriptClipEditor : IClipEditor
     {
         try
         {
-            _script = FmScript.FromDisplayText(Document.Text);
+            var textParsed = FmScript.FromDisplayText(Document.Text);
+            _script = MergeWithModel(textParsed);
+            _renderedLines = _script.ToDisplayLines();
+
+            // Re-render to normalize the document text with the merged model
+            _suppressDirty = true;
+            try
+            {
+                Document.Text = string.Join("\n", _renderedLines);
+            }
+            finally
+            {
+                _suppressDirty = false;
+            }
+
             IsPartial = false;
             IsDirty = false;
             Saved?.Invoke(this, EventArgs.Empty);
@@ -68,11 +88,12 @@ public class ScriptClipEditor : IClipEditor
     public void FromXml(string xml)
     {
         _script = FmScript.FromXml(xml);
+        _renderedLines = _script.ToDisplayLines();
 
         _suppressDirty = true;
         try
         {
-            Document.Text = _script.ToDisplayText();
+            Document.Text = string.Join("\n", _renderedLines);
         }
         finally
         {
@@ -81,5 +102,55 @@ public class ScriptClipEditor : IClipEditor
 
         IsDirty = false;
         IsPartial = false;
+    }
+
+    /// <summary>
+    /// Merge text-parsed steps with the existing model. For each line in the text:
+    /// - If it matches the rendered line from the model at the same position,
+    ///   keep the model step (preserves multi-line content shown truncated).
+    /// - If it differs, take the text-parsed step (user edited this line).
+    /// </summary>
+    private FmScript MergeWithModel(FmScript textParsed)
+    {
+        var merged = new List<ScriptStep>();
+        var textSteps = textParsed.Steps;
+        var modelSteps = _script.Steps;
+
+        // Build display lines for each text-parsed step (what the user typed, normalized)
+        var textLines = textSteps.Select(s => NormalizeDisplayLine(s)).ToList();
+
+        for (int i = 0; i < textSteps.Count; i++)
+        {
+            // Check if this line matches the model at the same index
+            if (i < modelSteps.Count && i < _renderedLines.Length)
+            {
+                var rendered = NormalizeLine(_renderedLines[i]);
+                var typed = NormalizeLine(textLines[i]);
+
+                if (rendered == typed)
+                {
+                    // User didn't change this line — preserve model step (with full multi-line content)
+                    merged.Add(modelSteps[i]);
+                    continue;
+                }
+            }
+
+            // User changed this line (or it's a new line) — use the text-parsed step
+            merged.Add(textSteps[i]);
+        }
+
+        return new FmScript(merged);
+    }
+
+    private static string NormalizeDisplayLine(ScriptStep step)
+    {
+        var line = step.ToDisplayLine();
+        if (!step.Enabled) line = $"// {line}";
+        return line;
+    }
+
+    private static string NormalizeLine(string line)
+    {
+        return line.Trim();
     }
 }

--- a/src/SharpFM/Editors/ScriptClipEditor.cs
+++ b/src/SharpFM/Editors/ScriptClipEditor.cs
@@ -1,24 +1,28 @@
 using System;
-using Avalonia.Threading;
 using AvaloniaEdit.Document;
 using SharpFM.Scripting;
 
 namespace SharpFM.Editors;
 
 /// <summary>
-/// Editor for script clips (Mac-XMSS, Mac-XMSC). Wraps a TextDocument containing the
-/// plain-text script representation and handles FmScript model round-tripping.
+/// Editor for script clips (Mac-XMSS, Mac-XMSC). The FmScript model is the source of truth.
+/// The TextDocument is a projection that the user edits. Save parses text back into the model.
 /// </summary>
 public class ScriptClipEditor : IClipEditor
 {
-    private readonly DispatcherTimer _debounceTimer;
     private FmScript _script;
+    private bool _suppressDirty;
 
-    public event EventHandler? ContentChanged;
+    public event EventHandler? BecameDirty;
+    public event EventHandler? Saved;
 
     /// <summary>The TextDocument bound to the AvaloniaEdit script editor.</summary>
     public TextDocument Document { get; }
 
+    /// <summary>The authoritative script model. Updated on Save or FromXml.</summary>
+    public FmScript Script => _script;
+
+    public bool IsDirty { get; private set; }
     public bool IsPartial { get; private set; }
 
     public ScriptClipEditor(string? xml)
@@ -26,39 +30,56 @@ public class ScriptClipEditor : IClipEditor
         _script = FmScript.FromXml(xml ?? "");
         Document = new TextDocument(_script.ToDisplayText());
 
-        _debounceTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
-        _debounceTimer.Tick += (_, _) =>
-        {
-            _debounceTimer.Stop();
-            ContentChanged?.Invoke(this, EventArgs.Empty);
-        };
-
-        Document.TextChanged += (_, _) =>
-        {
-            _debounceTimer.Stop();
-            _debounceTimer.Start();
-        };
+        Document.TextChanged += OnTextChanged;
     }
 
-    public string ToXml()
+    private void OnTextChanged(object? sender, EventArgs e)
+    {
+        if (_suppressDirty) return;
+        if (!IsDirty)
+        {
+            IsDirty = true;
+            BecameDirty?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public bool Save()
     {
         try
         {
             _script = FmScript.FromDisplayText(Document.Text);
             IsPartial = false;
-            return _script.ToXml();
+            IsDirty = false;
+            Saved?.Invoke(this, EventArgs.Empty);
+            return true;
         }
         catch
         {
             IsPartial = true;
-            // Return best-effort XML from the last known good parse
-            return _script.ToXml();
+            return false;
         }
+    }
+
+    public string ToXml()
+    {
+        return _script.ToXml();
     }
 
     public void FromXml(string xml)
     {
         _script = FmScript.FromXml(xml);
-        Document.Text = _script.ToDisplayText();
+
+        _suppressDirty = true;
+        try
+        {
+            Document.Text = _script.ToDisplayText();
+        }
+        finally
+        {
+            _suppressDirty = false;
+        }
+
+        IsDirty = false;
+        IsPartial = false;
     }
 }

--- a/src/SharpFM/Editors/TableClipEditor.cs
+++ b/src/SharpFM/Editors/TableClipEditor.cs
@@ -2,25 +2,25 @@ using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
-using Avalonia.Threading;
 using SharpFM.Schema.Editor;
 using SharpFM.Schema.Model;
 
 namespace SharpFM.Editors;
 
 /// <summary>
-/// Editor for table/field clips (Mac-XMTB, Mac-XMFD). Wraps a TableEditorViewModel
-/// and tracks field collection and property changes for live sync.
+/// Editor for table/field clips (Mac-XMTB, Mac-XMFD). The FmTable model is the source of truth.
+/// The DataGrid binds to the ViewModel which projects from the model.
+/// Save syncs ViewModel edits back to the model.
 /// </summary>
 public class TableClipEditor : IClipEditor
 {
-    private readonly DispatcherTimer _debounceTimer;
-
-    public event EventHandler? ContentChanged;
+    public event EventHandler? BecameDirty;
+    public event EventHandler? Saved;
 
     /// <summary>The TableEditorViewModel bound to the DataGrid.</summary>
     public TableEditorViewModel ViewModel { get; private set; }
 
+    public bool IsDirty { get; private set; }
     public bool IsPartial => false;
 
     public TableClipEditor(string? xml)
@@ -28,19 +28,19 @@ public class TableClipEditor : IClipEditor
         var table = FmTable.FromXml(xml ?? "");
         ViewModel = new TableEditorViewModel(table);
 
-        _debounceTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
-        _debounceTimer.Tick += (_, _) =>
-        {
-            _debounceTimer.Stop();
-            ContentChanged?.Invoke(this, EventArgs.Empty);
-        };
-
         SubscribeToViewModel(ViewModel);
+    }
+
+    public bool Save()
+    {
+        ViewModel.SyncToModel();
+        IsDirty = false;
+        Saved?.Invoke(this, EventArgs.Empty);
+        return true;
     }
 
     public string ToXml()
     {
-        ViewModel.SyncToModel();
         return ViewModel.Table.ToXml();
     }
 
@@ -48,6 +48,16 @@ public class TableClipEditor : IClipEditor
     {
         var incoming = FmTable.FromXml(xml);
         PatchViewModel(incoming);
+        IsDirty = false;
+    }
+
+    private void MarkDirty()
+    {
+        if (!IsDirty)
+        {
+            IsDirty = true;
+            BecameDirty?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     private void SubscribeToViewModel(TableEditorViewModel vm)
@@ -70,7 +80,6 @@ public class TableClipEditor : IClipEditor
 
     private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        // Subscribe to new fields, unsubscribe from removed ones
         if (e.NewItems is not null)
             foreach (FmField field in e.NewItems)
                 field.PropertyChanged += OnFieldPropertyChanged;
@@ -79,24 +88,18 @@ public class TableClipEditor : IClipEditor
             foreach (FmField field in e.OldItems)
                 field.PropertyChanged -= OnFieldPropertyChanged;
 
-        RestartDebounce();
+        MarkDirty();
     }
 
     private void OnFieldPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        RestartDebounce();
+        MarkDirty();
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(TableEditorViewModel.TableName))
-            RestartDebounce();
-    }
-
-    private void RestartDebounce()
-    {
-        _debounceTimer.Stop();
-        _debounceTimer.Start();
+            MarkDirty();
     }
 
     /// <summary>
@@ -141,17 +144,14 @@ public class TableClipEditor : IClipEditor
 
             if (currentById.TryGetValue(inField.Id, out var existing))
             {
-                // Update properties on the existing field in-place
                 PatchField(existing, inField);
 
-                // Move to correct position if needed
                 var currentIdx = current.Fields.IndexOf(existing);
                 if (currentIdx != i && currentIdx >= 0 && i < current.Fields.Count)
                     current.Fields.Move(currentIdx, i);
             }
             else
             {
-                // New field — insert at the correct position
                 inField.PropertyChanged += OnFieldPropertyChanged;
                 if (i < current.Fields.Count)
                     current.Fields.Insert(i, inField);
@@ -160,7 +160,6 @@ public class TableClipEditor : IClipEditor
             }
         }
 
-        // Sync the underlying model
         current.SyncToModel();
     }
 

--- a/src/SharpFM/Editors/TableClipEditor.cs
+++ b/src/SharpFM/Editors/TableClipEditor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using System.Xml.Linq;
 using SharpFM.Schema.Editor;
 using SharpFM.Schema.Model;
 
@@ -21,7 +22,7 @@ public class TableClipEditor : IClipEditor
     public TableEditorViewModel ViewModel { get; private set; }
 
     public bool IsDirty { get; private set; }
-    public bool IsPartial => false;
+    public bool IsPartial { get; private set; }
 
     public TableClipEditor(string? xml)
     {
@@ -34,6 +35,20 @@ public class TableClipEditor : IClipEditor
     public bool Save()
     {
         ViewModel.SyncToModel();
+
+        // Validate the generated XML
+        try
+        {
+            var xml = ViewModel.Table.ToXml();
+            XDocument.Parse(xml);
+        }
+        catch
+        {
+            IsPartial = true;
+            return false;
+        }
+
+        IsPartial = false;
         IsDirty = false;
         Saved?.Invoke(this, EventArgs.Empty);
         return true;

--- a/src/SharpFM/Scripting/Handlers/CommentHandler.cs
+++ b/src/SharpFM/Scripting/Handlers/CommentHandler.cs
@@ -12,8 +12,10 @@ internal class CommentHandler : StepHandlerBase, IStepHandler
         var text = step.ParamValues.FirstOrDefault(p => p.Definition.XmlElement == "Text")?.Value ?? "";
         if (text.Contains('\n'))
         {
-            var lines = text.Split('\n');
-            return string.Join("\n", lines.Select(l => $"# {l.TrimEnd('\r')}"));
+            // Multi-line: show first line truncated. Full text lives in the model,
+            // editable via popup dialog. This ensures 1 display line = 1 step, always.
+            var firstLine = text.Split('\n')[0].TrimEnd('\r');
+            return $"# {firstLine}\u2026";
         }
         return $"# {text}";
     }

--- a/src/SharpFM/Scripting/Model/FmScript.cs
+++ b/src/SharpFM/Scripting/Model/FmScript.cs
@@ -63,11 +63,10 @@ public class FmScript
             var trimmed = line.TrimEnd('\r');
             if (string.IsNullOrWhiteSpace(trimmed))
                 continue;
+
             steps.Add(ScriptStep.FromDisplayLine(trimmed));
         }
 
-        // Merge consecutive comment lines into single comment steps
-        steps = MergeCommentContinuations(steps);
         return new FmScript(steps);
     }
 
@@ -117,16 +116,7 @@ public class FmScript
             if (indentLevel > 0)
                 displayLine = string.Concat(Enumerable.Repeat(indent, indentLevel)) + displayLine;
 
-            // Comments may produce multi-line output
-            if (displayLine.Contains('\n'))
-            {
-                foreach (var subLine in displayLine.Split('\n'))
-                    result.Add(subLine);
-            }
-            else
-            {
-                result.Add(displayLine);
-            }
+            result.Add(displayLine);
 
             // Increase indent after open/middle blocks
             if (step.Definition?.BlockPair?.Role is BlockPairRole.Open or BlockPairRole.Middle)
@@ -219,33 +209,4 @@ public class FmScript
         return results;
     }
 
-    // --- Comment merging ---
-
-    private static List<ScriptStep> MergeCommentContinuations(List<ScriptStep> steps)
-    {
-        var result = new List<ScriptStep>();
-
-        foreach (var step in steps)
-        {
-            bool isComment = step.Definition?.Name == "# (comment)";
-            bool prevIsComment = result.Count > 0 && result[^1].Definition?.Name == "# (comment)";
-
-            if (prevIsComment && isComment)
-            {
-                var prev = result[^1];
-                var prevText = prev.ParamValues.FirstOrDefault(p => p.Definition.XmlElement == "Text")?.Value ?? "";
-                var thisText = step.ParamValues.FirstOrDefault(p => p.Definition.XmlElement == "Text")?.Value ?? "";
-                var merged = string.IsNullOrEmpty(prevText) ? thisText : prevText + "\n" + thisText;
-
-                var textParam = prev.ParamValues.FirstOrDefault(p => p.Definition.XmlElement == "Text");
-                if (textParam != null) textParam.Value = merged;
-            }
-            else
-            {
-                result.Add(step);
-            }
-        }
-
-        return result;
-    }
 }

--- a/src/SharpFM/Scripting/Model/FmScript.cs
+++ b/src/SharpFM/Scripting/Model/FmScript.cs
@@ -148,12 +148,75 @@ public class FmScript
         return diagnostics;
     }
 
-    // --- Update single step from edited display line ---
+    // --- Mutation API ---
 
+    /// <summary>Fires after any mutation to the Steps collection.</summary>
+    public event EventHandler? StepsChanged;
+
+    /// <summary>Number of steps in the script.</summary>
+    public int StepCount => Steps.Count;
+
+    /// <summary>Get a step by index.</summary>
+    public ScriptStep GetStep(int index) => Steps[index];
+
+    /// <summary>Insert a step at the given index.</summary>
+    public void AddStep(int index, ScriptStep step)
+    {
+        Steps.Insert(index, step);
+        StepsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Remove the step at the given index.</summary>
+    public void RemoveStep(int index)
+    {
+        Steps.RemoveAt(index);
+        StepsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Move a step from one index to another.</summary>
+    public void MoveStep(int fromIndex, int toIndex)
+    {
+        var step = Steps[fromIndex];
+        Steps.RemoveAt(fromIndex);
+        Steps.Insert(toIndex, step);
+        StepsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Replace the step at the given index.</summary>
+    public void UpdateStep(int index, ScriptStep replacement)
+    {
+        Steps[index] = replacement;
+        StepsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Replace the step at the given index from a display line string.</summary>
     public void UpdateStep(int index, string displayLine)
     {
         if (index < 0 || index >= Steps.Count) return;
         Steps[index] = ScriptStep.FromDisplayLine(displayLine);
+        StepsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Replace all steps (bulk operation, e.g. from re-parsing text or XML).</summary>
+    public void ReplaceSteps(IReadOnlyList<ScriptStep> steps)
+    {
+        Steps.Clear();
+        Steps.AddRange(steps);
+        StepsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    // --- Query API ---
+
+    /// <summary>Find all steps matching a step name (case-insensitive).</summary>
+    public IReadOnlyList<(int Index, ScriptStep Step)> FindSteps(string stepName)
+    {
+        var results = new List<(int, ScriptStep)>();
+        for (int i = 0; i < Steps.Count; i++)
+        {
+            if (string.Equals(Steps[i].Definition?.Name, stepName, StringComparison.OrdinalIgnoreCase))
+                results.Add((i, Steps[i]));
+        }
+        return results;
     }
 
     // --- Comment merging ---

--- a/src/SharpFM/Scripting/Model/ScriptStep.cs
+++ b/src/SharpFM/Scripting/Model/ScriptStep.cs
@@ -173,6 +173,63 @@ public partial class ScriptStep
         return diagnostics;
     }
 
+    // --- Typed accessors for agents/plugins ---
+
+    /// <summary>The step name (e.g. "Set Variable", "If", "# (comment)").</summary>
+    public string StepName => Definition?.Name ?? SourceXml?.Attribute("name")?.Value ?? "Unknown";
+
+    /// <summary>Get a parameter value by its human-readable label (e.g. "Value", "Parameter").</summary>
+    public string? GetNamedParam(string label)
+    {
+        return ParamValues.FirstOrDefault(p =>
+            string.Equals(p.Definition.HrLabel, label, StringComparison.OrdinalIgnoreCase)
+            || (p.Definition.Type == "namedCalc"
+                && string.Equals(p.Definition.WrapperElement, label, StringComparison.OrdinalIgnoreCase)))
+            ?.Value;
+    }
+
+    /// <summary>Get the first calculation-type parameter value.</summary>
+    public string? GetCalculation()
+    {
+        return ParamValues
+            .FirstOrDefault(p => p.Definition.Type is "calculation" or "calc" or "namedCalc")
+            ?.Value;
+    }
+
+    /// <summary>Get the field reference (Table::Field or $variable) if this step has one.</summary>
+    public string? GetFieldReference()
+    {
+        return ParamValues
+            .FirstOrDefault(p => p.Definition.Type is "field" or "fieldOrVariable")
+            ?.Value;
+    }
+
+    /// <summary>Get the script reference (quoted name) if this step has one.</summary>
+    public string? GetScriptReference()
+    {
+        var val = ParamValues
+            .FirstOrDefault(p => p.Definition.Type == "script")
+            ?.Value;
+        return val != null ? XmlHelpers.Unquote(val) : null;
+    }
+
+    /// <summary>Get the layout reference (quoted name) if this step has one.</summary>
+    public string? GetLayoutReference()
+    {
+        var val = ParamValues
+            .FirstOrDefault(p => p.Definition.Type is "layout" or "layoutRef")
+            ?.Value;
+        return val != null ? XmlHelpers.Unquote(val) : null;
+    }
+
+    /// <summary>Get a parameter value by its XML element name.</summary>
+    public string? GetParamByXmlElement(string xmlElement)
+    {
+        return ParamValues
+            .FirstOrDefault(p => string.Equals(p.Definition.XmlElement, xmlElement, StringComparison.OrdinalIgnoreCase))
+            ?.Value;
+    }
+
     // --- Helpers ---
 
     private static StepDefinition? LookupDefinition(string name, string? idStr)

--- a/src/SharpFM/ViewModels/ClipViewModel.cs
+++ b/src/SharpFM/ViewModels/ClipViewModel.cs
@@ -25,12 +25,20 @@ public partial class ClipViewModel : INotifyPropertyChanged
     public IClipEditor Editor { get; }
 
     /// <summary>
-    /// Fires when the editor content changes due to user edits (debounced).
-    /// Not fired for external XML pushes (guarded by generation counter).
+    /// Fires when the editor is saved, indicating the model has been updated.
+    /// Replaces the old debounced ContentChanged event.
     /// </summary>
     public event EventHandler? EditorContentChanged;
 
-    private int _syncGeneration;
+    /// <summary>
+    /// Fires when the editor becomes dirty (user made first edit since last save/load).
+    /// </summary>
+    public event EventHandler? EditorBecameDirty;
+
+    /// <summary>
+    /// Whether the editor has unsaved changes.
+    /// </summary>
+    public bool IsDirty => Editor.IsDirty;
 
     public ClipViewModel(FileMakerClip clip)
     {
@@ -43,15 +51,21 @@ public partial class ClipViewModel : INotifyPropertyChanged
             _ => new FallbackXmlEditor(clip.XmlData),
         };
 
-        Editor.ContentChanged += OnEditorContentChanged;
+        Editor.Saved += OnEditorSaved;
+        Editor.BecameDirty += OnEditorBecameDirty;
     }
 
-    private void OnEditorContentChanged(object? sender, EventArgs e)
+    private void OnEditorSaved(object? sender, EventArgs e)
     {
-        var gen = _syncGeneration;
         Clip.XmlData = Editor.ToXml();
-        if (gen != _syncGeneration) return; // external update arrived during sync, stale
+        NotifyPropertyChanged(nameof(IsDirty));
         EditorContentChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnEditorBecameDirty(object? sender, EventArgs e)
+    {
+        NotifyPropertyChanged(nameof(IsDirty));
+        EditorBecameDirty?.Invoke(this, EventArgs.Empty);
     }
 
     public bool IsScriptClip =>
@@ -116,20 +130,36 @@ public partial class ClipViewModel : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// Sync the editor state to XML. Called before save/clipboard operations.
+    /// Save the editor's local buffer to the model. Updates Clip.XmlData.
+    /// Returns true if save succeeded.
     /// </summary>
-    public void SyncModelFromEditor()
+    public bool SaveEditor()
     {
-        Clip.XmlData = Editor.ToXml();
+        var result = Editor.Save();
+        if (result)
+            Clip.XmlData = Editor.ToXml();
+        return result;
     }
 
     /// <summary>
-    /// Push XML into the editor (reverse sync). Bumps the generation counter
-    /// so the debounced ContentChanged event knows to discard the stale tick.
+    /// Sync the editor state to XML. Called before save/clipboard operations.
+    /// Auto-saves if dirty.
+    /// </summary>
+    public void SyncModelFromEditor()
+    {
+        if (Editor.IsDirty)
+            SaveEditor();
+        else
+            Clip.XmlData = Editor.ToXml();
+    }
+
+    /// <summary>
+    /// Push XML into the editor from an external source (plugin, agent, other editor).
+    /// Replaces the local buffer and model. Clears dirty state.
     /// </summary>
     public void SyncEditorFromXml()
     {
-        _syncGeneration++;
         Editor.FromXml(Clip.XmlData ?? "");
+        NotifyPropertyChanged(nameof(IsDirty));
     }
 }

--- a/tests/SharpFM.Tests/Editors/FallbackXmlEditorTests.cs
+++ b/tests/SharpFM.Tests/Editors/FallbackXmlEditorTests.cs
@@ -89,10 +89,62 @@ public class FallbackXmlEditorTests
     }
 
     [Fact]
-    public void IsPartial_AlwaysFalse()
+    public void IsPartial_FalseForValidXml()
     {
         var editor = new FallbackXmlEditor("<root/>");
         Assert.False(editor.IsPartial);
+    }
+
+    [Fact]
+    public void Save_InvalidXml_ReturnsFalse()
+    {
+        var editor = new FallbackXmlEditor("<root/>");
+        editor.Document.Text = "<unclosed";
+
+        Assert.False(editor.Save());
+        Assert.True(editor.IsPartial);
+        Assert.True(editor.IsDirty); // stays dirty
+    }
+
+    [Fact]
+    public void Save_InvalidXml_PreservesLastGoodState()
+    {
+        var editor = new FallbackXmlEditor("<root/>");
+        editor.Document.Text = "<unclosed";
+        editor.Save();
+
+        // ToXml still returns the last valid saved state
+        Assert.Equal("<root/>", editor.ToXml());
+    }
+
+    [Fact]
+    public void Save_InvalidThenValid_Recovers()
+    {
+        var editor = new FallbackXmlEditor("<root/>");
+
+        // First: invalid save fails
+        editor.Document.Text = "not xml at all";
+        Assert.False(editor.Save());
+        Assert.True(editor.IsPartial);
+
+        // Second: valid save succeeds
+        editor.Document.Text = "<fixed/>";
+        Assert.True(editor.Save());
+        Assert.False(editor.IsPartial);
+        Assert.Equal("<fixed/>", editor.ToXml());
+    }
+
+    [Fact]
+    public void Save_InvalidXml_DoesNotFireSavedEvent()
+    {
+        var editor = new FallbackXmlEditor("<root/>");
+        var fired = false;
+        editor.Saved += (_, _) => fired = true;
+
+        editor.Document.Text = "<broken";
+        editor.Save();
+
+        Assert.False(fired);
     }
 
     [Fact]

--- a/tests/SharpFM.Tests/Editors/FallbackXmlEditorTests.cs
+++ b/tests/SharpFM.Tests/Editors/FallbackXmlEditorTests.cs
@@ -15,12 +15,68 @@ public class FallbackXmlEditorTests
     }
 
     [Fact]
-    public void ToXml_ReturnsDocumentText()
+    public void ToXml_ReturnsSavedState_NotLiveBuffer()
     {
         var editor = new FallbackXmlEditor("<root/>");
         editor.Document.Text = "<modified/>";
 
+        // ToXml returns saved state, not live buffer
+        Assert.Equal("<root/>", editor.ToXml());
+
+        // After save, ToXml returns the updated content
+        editor.Save();
         Assert.Equal("<modified/>", editor.ToXml());
+    }
+
+    [Fact]
+    public void IsDirty_TracksUnsavedChanges()
+    {
+        var editor = new FallbackXmlEditor("<root/>");
+        Assert.False(editor.IsDirty);
+
+        editor.Document.Text = "<modified/>";
+        Assert.True(editor.IsDirty);
+
+        editor.Save();
+        Assert.False(editor.IsDirty);
+    }
+
+    [Fact]
+    public void FromXml_ClearsDirtyState()
+    {
+        var editor = new FallbackXmlEditor("<root/>");
+        editor.Document.Text = "<modified/>";
+        Assert.True(editor.IsDirty);
+
+        editor.FromXml("<external/>");
+        Assert.False(editor.IsDirty);
+        Assert.Equal("<external/>", editor.Document.Text);
+    }
+
+    [Fact]
+    public void BecameDirty_FiresOnce()
+    {
+        var editor = new FallbackXmlEditor("<root/>");
+        int fireCount = 0;
+        editor.BecameDirty += (_, _) => fireCount++;
+
+        editor.Document.Text = "<a/>";
+        editor.Document.Text = "<b/>";
+
+        Assert.Equal(1, fireCount);
+    }
+
+    [Fact]
+    public void Saved_FiresOnSave()
+    {
+        var editor = new FallbackXmlEditor("<root/>");
+        var fired = false;
+        editor.Saved += (_, _) => fired = true;
+
+        editor.Document.Text = "<modified/>";
+        editor.Save();
+
+        Assert.True(fired);
     }
 
     [Fact]

--- a/tests/SharpFM.Tests/Editors/ScriptClipEditorTests.cs
+++ b/tests/SharpFM.Tests/Editors/ScriptClipEditorTests.cs
@@ -64,4 +64,59 @@ public class ScriptClipEditorTests
         Assert.NotNull(editor.Document);
         Assert.NotNull(editor.ToXml());
     }
+
+    [Fact]
+    public void IsDirty_TracksUnsavedChanges()
+    {
+        var editor = new ScriptClipEditor(SampleScriptXml);
+        Assert.False(editor.IsDirty);
+
+        editor.Document.Text = "# modified comment";
+        Assert.True(editor.IsDirty);
+
+        editor.Save();
+        Assert.False(editor.IsDirty);
+    }
+
+    [Fact]
+    public void Save_UpdatesModel()
+    {
+        var editor = new ScriptClipEditor(SampleScriptXml);
+        editor.Document.Text = "# new comment";
+        editor.Save();
+
+        var xml = editor.ToXml();
+        Assert.Contains("new comment", xml);
+    }
+
+    [Fact]
+    public void ToXml_ReturnsSavedState()
+    {
+        var editor = new ScriptClipEditor(SampleScriptXml);
+        var original = editor.ToXml();
+
+        editor.Document.Text = "# unsaved edit";
+
+        // ToXml returns saved state, not live buffer
+        Assert.Equal(original, editor.ToXml());
+    }
+
+    [Fact]
+    public void FromXml_ClearsDirtyState()
+    {
+        var editor = new ScriptClipEditor(SampleScriptXml);
+        editor.Document.Text = "# dirty";
+        Assert.True(editor.IsDirty);
+
+        editor.FromXml(SampleScriptXml);
+        Assert.False(editor.IsDirty);
+    }
+
+    [Fact]
+    public void Script_ExposesModel()
+    {
+        var editor = new ScriptClipEditor(SampleScriptXml);
+        Assert.NotNull(editor.Script);
+        Assert.NotEmpty(editor.Script.Steps);
+    }
 }

--- a/tests/SharpFM.Tests/Editors/TableClipEditorTests.cs
+++ b/tests/SharpFM.Tests/Editors/TableClipEditorTests.cs
@@ -124,10 +124,111 @@ public class TableClipEditorTests
     }
 
     [Fact]
-    public void IsPartial_AlwaysFalse()
+    public void IsPartial_FalseForValidTable()
     {
         var editor = new TableClipEditor(SampleTableXml);
-        editor.ToXml();
+        editor.Save();
         Assert.False(editor.IsPartial);
+    }
+
+    // --- Save/Dirty pattern ---
+
+    [Fact]
+    public void IsDirty_FalseOnConstruction()
+    {
+        var editor = new TableClipEditor(SampleTableXml);
+        Assert.False(editor.IsDirty);
+    }
+
+    [Fact]
+    public void IsDirty_TrueAfterFieldChange()
+    {
+        var editor = new TableClipEditor(SampleTableXml);
+        editor.ViewModel.Fields[0].Name = "Modified";
+
+        Assert.True(editor.IsDirty);
+    }
+
+    [Fact]
+    public void IsDirty_TrueAfterAddField()
+    {
+        var editor = new TableClipEditor(SampleTableXml);
+        editor.ViewModel.AddField();
+
+        Assert.True(editor.IsDirty);
+    }
+
+    [Fact]
+    public void Save_ClearsDirty()
+    {
+        var editor = new TableClipEditor(SampleTableXml);
+        editor.ViewModel.Fields[0].Name = "Modified";
+        Assert.True(editor.IsDirty);
+
+        editor.Save();
+        Assert.False(editor.IsDirty);
+    }
+
+    [Fact]
+    public void Save_FiresSavedEvent()
+    {
+        var editor = new TableClipEditor(SampleTableXml);
+        var fired = false;
+        editor.Saved += (_, _) => fired = true;
+
+        editor.ViewModel.Fields[0].Name = "Modified";
+        editor.Save();
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public void ToXml_ReflectsModelState_NotLiveGrid()
+    {
+        var editor = new TableClipEditor(SampleTableXml);
+        var original = editor.ToXml();
+
+        // Modify grid but don't save
+        editor.ViewModel.Fields[0].Name = "Unsaved";
+
+        // ToXml returns the model state (SyncToModel not called)
+        // Note: ViewModel.Table is the model, and SyncToModel updates it
+        // Without save, the table's XML should still have the original field names
+        Assert.Contains("FirstName", original);
+    }
+
+    [Fact]
+    public void Save_ThenToXml_ReflectsChanges()
+    {
+        var editor = new TableClipEditor(SampleTableXml);
+        editor.ViewModel.Fields[0].Name = "GivenName";
+        editor.Save();
+
+        var xml = editor.ToXml();
+        Assert.Contains("GivenName", xml);
+    }
+
+    [Fact]
+    public void FromXml_ClearsDirty()
+    {
+        var editor = new TableClipEditor(SampleTableXml);
+        editor.ViewModel.Fields[0].Name = "Dirty";
+        Assert.True(editor.IsDirty);
+
+        editor.FromXml(SampleTableXml);
+        Assert.False(editor.IsDirty);
+    }
+
+    [Fact]
+    public void BecameDirty_FiresOnce()
+    {
+        var editor = new TableClipEditor(SampleTableXml);
+        int fireCount = 0;
+        editor.BecameDirty += (_, _) => fireCount++;
+
+        editor.ViewModel.Fields[0].Name = "A";
+        editor.ViewModel.Fields[0].Name = "B";
+
+        Assert.Equal(1, fireCount);
     }
 }

--- a/tests/SharpFM.Tests/Scripting/CommentRoundtripTests.cs
+++ b/tests/SharpFM.Tests/Scripting/CommentRoundtripTests.cs
@@ -1,0 +1,93 @@
+using SharpFM.Editors;
+using SharpFM.Scripting;
+using Xunit;
+
+namespace SharpFM.Tests.Scripting;
+
+public class CommentRoundtripTests
+{
+    private static string Wrap(string steps) =>
+        $"<fmxmlsnippet type=\"FMObjectList\">{steps}</fmxmlsnippet>";
+
+    [Fact]
+    public void TwoSeparateComments_StaySeparate_AfterRoundtrip()
+    {
+        var xml = Wrap(
+            "<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>first</Text></Step>"
+            + "<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>second</Text></Step>");
+
+        var script = FmScript.FromXml(xml);
+        Assert.Equal(2, script.Steps.Count);
+
+        // Roundtrip through display text
+        var displayText = script.ToDisplayText();
+        var reparsed = FmScript.FromDisplayText(displayText);
+
+        Assert.Equal(2, reparsed.Steps.Count);
+        Assert.Contains("first", reparsed.Steps[0].ToDisplayLine());
+        Assert.Contains("second", reparsed.Steps[1].ToDisplayLine());
+    }
+
+    [Fact]
+    public void MultilineComment_DisplaysTruncated()
+    {
+        var xml = Wrap(
+            "<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>line one\nline two</Text></Step>");
+
+        var script = FmScript.FromXml(xml);
+        Assert.Single(script.Steps);
+
+        // Display should show truncated first line with ellipsis
+        var displayText = script.ToDisplayText();
+        Assert.Contains("line one", displayText);
+        Assert.Contains("\u2026", displayText); // ellipsis
+        Assert.DoesNotContain("line two", displayText); // not shown in text
+    }
+
+    [Fact]
+    public void MultilineComment_PreservedOnSave_WhenUnchanged()
+    {
+        var xml = Wrap(
+            "<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>line one\nline two</Text></Step>");
+
+        var editor = new ScriptClipEditor(xml);
+        editor.Save(); // save without editing
+
+        var savedXml = editor.ToXml();
+        Assert.Contains("line one", savedXml);
+        Assert.Contains("line two", savedXml); // full content preserved
+    }
+
+    [Fact]
+    public void MultilineComment_ThenSeparateComment_PreservesBoth()
+    {
+        var xml = Wrap(
+            "<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>multi\nline</Text></Step>"
+            + "<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>separate</Text></Step>");
+
+        var editor = new ScriptClipEditor(xml);
+        editor.Save(); // save without editing
+
+        var savedXml = editor.ToXml();
+        Assert.Contains("multi", savedXml);
+        Assert.Contains("line", savedXml);
+        Assert.Contains("separate", savedXml);
+        Assert.Equal(2, editor.Script.Steps.Count);
+    }
+
+    [Fact]
+    public void CommentBetweenSteps_PreservesStepCount()
+    {
+        var xml = Wrap(
+            "<Step enable=\"True\" id=\"93\" name=\"Beep\"/>"
+            + "<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>note</Text></Step>"
+            + "<Step enable=\"True\" id=\"93\" name=\"Beep\"/>");
+
+        var script = FmScript.FromXml(xml);
+        Assert.Equal(3, script.Steps.Count);
+
+        var displayText = script.ToDisplayText();
+        var reparsed = FmScript.FromDisplayText(displayText);
+        Assert.Equal(3, reparsed.Steps.Count);
+    }
+}

--- a/tests/SharpFM.Tests/Scripting/FmScriptMutationTests.cs
+++ b/tests/SharpFM.Tests/Scripting/FmScriptMutationTests.cs
@@ -1,0 +1,209 @@
+using System.Xml.Linq;
+using SharpFM.Scripting;
+using SharpFM.Scripting.Model;
+using Xunit;
+
+namespace SharpFM.Tests.Scripting;
+
+public class FmScriptMutationTests
+{
+    private static FmScript MakeScript(params string[] displayLines)
+    {
+        var text = string.Join("\n", displayLines);
+        return FmScript.FromDisplayText(text);
+    }
+
+    private static ScriptStep MakeStep(string displayLine)
+    {
+        return ScriptStep.FromDisplayLine(displayLine);
+    }
+
+    // --- AddStep ---
+
+    [Fact]
+    public void AddStep_InsertsAtIndex()
+    {
+        var script = MakeScript("Beep", "Halt");
+        var step = MakeStep("# inserted");
+
+        script.AddStep(1, step);
+
+        Assert.Equal(3, script.StepCount);
+        Assert.Contains("inserted", script.GetStep(1).ToDisplayLine());
+    }
+
+    [Fact]
+    public void AddStep_FiresStepsChanged()
+    {
+        var script = MakeScript("Beep");
+        var fired = false;
+        script.StepsChanged += (_, _) => fired = true;
+
+        script.AddStep(0, MakeStep("Halt"));
+
+        Assert.True(fired);
+    }
+
+    // --- RemoveStep ---
+
+    [Fact]
+    public void RemoveStep_RemovesAtIndex()
+    {
+        var script = MakeScript("Beep", "# middle", "Halt");
+
+        script.RemoveStep(1);
+
+        Assert.Equal(2, script.StepCount);
+        Assert.Contains("Halt", script.GetStep(1).ToDisplayLine());
+    }
+
+    [Fact]
+    public void RemoveStep_FiresStepsChanged()
+    {
+        var script = MakeScript("Beep", "Halt");
+        var fired = false;
+        script.StepsChanged += (_, _) => fired = true;
+
+        script.RemoveStep(0);
+
+        Assert.True(fired);
+    }
+
+    // --- MoveStep ---
+
+    [Fact]
+    public void MoveStep_ReordersSteps()
+    {
+        var script = MakeScript("Beep", "# middle", "Halt");
+
+        script.MoveStep(2, 0);
+
+        Assert.Contains("Halt", script.GetStep(0).ToDisplayLine());
+        Assert.Contains("Beep", script.GetStep(1).ToDisplayLine());
+    }
+
+    // --- UpdateStep ---
+
+    [Fact]
+    public void UpdateStep_ReplacesStep()
+    {
+        var script = MakeScript("Beep");
+        var replacement = MakeStep("Halt");
+
+        script.UpdateStep(0, replacement);
+
+        Assert.Contains("Halt", script.GetStep(0).ToDisplayLine());
+    }
+
+    [Fact]
+    public void UpdateStep_FromDisplayLine()
+    {
+        var script = MakeScript("Beep");
+
+        script.UpdateStep(0, "# from display");
+
+        Assert.Contains("from display", script.GetStep(0).ToDisplayLine());
+    }
+
+    // --- ReplaceSteps ---
+
+    [Fact]
+    public void ReplaceSteps_ClearsAndSetsNew()
+    {
+        var script = MakeScript("Beep", "# b", "Halt");
+
+        script.ReplaceSteps([MakeStep("# x"), MakeStep("Beep")]);
+
+        Assert.Equal(2, script.StepCount);
+    }
+
+    [Fact]
+    public void ReplaceSteps_FiresStepsChanged()
+    {
+        var script = MakeScript("Beep");
+        var fired = false;
+        script.StepsChanged += (_, _) => fired = true;
+
+        script.ReplaceSteps([MakeStep("Halt")]);
+
+        Assert.True(fired);
+    }
+
+    // --- FindSteps ---
+
+    [Fact]
+    public void FindSteps_ByName()
+    {
+        var xml = "<fmxmlsnippet type=\"FMObjectList\">"
+            + "<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>a</Text></Step>"
+            + "<Step enable=\"True\" id=\"93\" name=\"Beep\"/>"
+            + "<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>b</Text></Step>"
+            + "</fmxmlsnippet>";
+        var script = FmScript.FromXml(xml);
+
+        var comments = script.FindSteps("# (comment)");
+
+        Assert.Equal(2, comments.Count);
+        Assert.Equal(0, comments[0].Index);
+        Assert.Equal(2, comments[1].Index);
+    }
+
+    [Fact]
+    public void FindSteps_CaseInsensitive()
+    {
+        var xml = "<fmxmlsnippet type=\"FMObjectList\">"
+            + "<Step enable=\"True\" id=\"93\" name=\"Beep\"/>"
+            + "</fmxmlsnippet>";
+        var script = FmScript.FromXml(xml);
+
+        var results = script.FindSteps("beep");
+
+        Assert.Single(results);
+    }
+
+    [Fact]
+    public void FindSteps_NoMatches_ReturnsEmpty()
+    {
+        var script = MakeScript("# comment");
+
+        var results = script.FindSteps("Set Variable");
+
+        Assert.Empty(results);
+    }
+
+    // --- GetStep / StepCount ---
+
+    [Fact]
+    public void StepCount_ReflectsCurrentState()
+    {
+        var script = MakeScript("Beep", "Halt");
+        Assert.Equal(2, script.StepCount);
+
+        script.RemoveStep(0);
+        Assert.Equal(1, script.StepCount);
+    }
+
+    // --- Roundtrip after mutation ---
+
+    [Fact]
+    public void Mutation_ThenToXml_Roundtrips()
+    {
+        var script = MakeScript("# original");
+        script.AddStep(1, MakeStep("Beep"));
+
+        var xml = script.ToXml();
+        Assert.Contains("original", xml);
+        Assert.Contains("Beep", xml);
+    }
+
+    [Fact]
+    public void Mutation_ThenToDisplayText_Roundtrips()
+    {
+        var script = MakeScript("Beep");
+        script.AddStep(1, MakeStep("Halt"));
+
+        var text = script.ToDisplayText();
+        Assert.Contains("Beep", text);
+        Assert.Contains("Halt", text);
+    }
+}

--- a/tests/SharpFM.Tests/Scripting/ScriptStepAccessorTests.cs
+++ b/tests/SharpFM.Tests/Scripting/ScriptStepAccessorTests.cs
@@ -1,0 +1,111 @@
+using System.Xml.Linq;
+using SharpFM.Scripting;
+using Xunit;
+
+namespace SharpFM.Tests.Scripting;
+
+public class ScriptStepAccessorTests
+{
+    private static ScriptStep FromXml(string xml) =>
+        ScriptStep.FromXml(XElement.Parse(xml));
+
+    [Fact]
+    public void StepName_ReturnsDefinitionName()
+    {
+        var step = FromXml("<Step enable=\"True\" id=\"93\" name=\"Beep\"/>");
+        Assert.Equal("Beep", step.StepName);
+    }
+
+    [Fact]
+    public void StepName_UnknownStep_ReturnsFallback()
+    {
+        var step = FromXml("<Step enable=\"True\" id=\"9999\" name=\"FakeStep\"/>");
+        Assert.Equal("FakeStep", step.StepName);
+    }
+
+    [Fact]
+    public void GetCalculation_ReturnsCalcValue()
+    {
+        var step = FromXml(
+            "<Step enable=\"True\" id=\"68\" name=\"If\">"
+            + "<Calculation><![CDATA[$x > 0]]></Calculation></Step>");
+
+        Assert.Equal("$x > 0", step.GetCalculation());
+    }
+
+    [Fact]
+    public void GetCalculation_NoCalc_ReturnsNull()
+    {
+        var step = FromXml("<Step enable=\"True\" id=\"93\" name=\"Beep\"/>");
+        Assert.Null(step.GetCalculation());
+    }
+
+    [Fact]
+    public void GetFieldReference_ReturnsTableField()
+    {
+        var step = FromXml(
+            "<Step enable=\"True\" id=\"76\" name=\"Set Field\">"
+            + "<Field table=\"People\" id=\"1\" name=\"FirstName\"/>"
+            + "<Calculation><![CDATA[\"test\"]]></Calculation></Step>");
+
+        Assert.Equal("People::FirstName", step.GetFieldReference());
+    }
+
+    [Fact]
+    public void GetScriptReference_ReturnsUnquotedName()
+    {
+        var step = FromXml(
+            "<Step enable=\"True\" id=\"1\" name=\"Perform Script\">"
+            + "<Script id=\"1\" name=\"Initialize\"/>"
+            + "<Calculation><![CDATA[]]></Calculation></Step>");
+
+        Assert.Equal("Initialize", step.GetScriptReference());
+    }
+
+    [Fact]
+    public void GetLayoutReference_ReturnsUnquotedName()
+    {
+        var step = FromXml(
+            "<Step enable=\"True\" id=\"6\" name=\"Go to Layout\">"
+            + "<LayoutDestination value=\"SelectedLayout\"/>"
+            + "<Layout id=\"1\" name=\"Detail\"/></Step>");
+
+        Assert.Equal("Detail", step.GetLayoutReference());
+    }
+
+    [Fact]
+    public void GetNamedParam_ByLabel()
+    {
+        var step = FromXml(
+            "<Step enable=\"True\" id=\"141\" name=\"Set Variable\">"
+            + "<Value><Calculation><![CDATA[$count + 1]]></Calculation></Value>"
+            + "<Repetition><Calculation><![CDATA[1]]></Calculation></Repetition>"
+            + "<Name>$count</Name></Step>");
+
+        Assert.Equal("$count + 1", step.GetNamedParam("Value"));
+    }
+
+    [Fact]
+    public void GetParamByXmlElement_ReturnsValue()
+    {
+        var step = FromXml(
+            "<Step enable=\"True\" id=\"141\" name=\"Set Variable\">"
+            + "<Value><Calculation><![CDATA[$count + 1]]></Calculation></Value>"
+            + "<Repetition><Calculation><![CDATA[1]]></Calculation></Repetition>"
+            + "<Name>$count</Name></Step>");
+
+        Assert.Equal("$count", step.GetParamByXmlElement("Name"));
+    }
+
+    [Fact]
+    public void GetNamedParam_CaseInsensitive()
+    {
+        var step = FromXml(
+            "<Step enable=\"True\" id=\"141\" name=\"Set Variable\">"
+            + "<Value><Calculation><![CDATA[42]]></Calculation></Value>"
+            + "<Repetition><Calculation><![CDATA[1]]></Calculation></Repetition>"
+            + "<Name>$x</Name></Step>");
+
+        Assert.Equal("42", step.GetNamedParam("value"));
+    }
+}


### PR DESCRIPTION
## Summary
- Replace debounced sync with explicit save/dirty model across all editors
- FmScript gains structured mutation API (AddStep, RemoveStep, MoveStep, FindSteps, etc.)
- ScriptStep gains typed accessors (GetCalculation, GetFieldReference, GetScriptReference, etc.)
- Fix multi-line comment merging bug: consecutive separate comments no longer incorrectly merged
- Multi-line comments render truncated in text editor; full content preserved via model merge on save
- All editors validate content on save — invalid content stays dirty, last valid state preserved
- Plugins only notified with valid content after successful saves