### PR TITLE
fix: release artifact glob exclude SharpFM.sln

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -53,6 +53,10 @@ jobs:
       - name: Publish
         uses: softprops/action-gh-release@v2
         with:
-          files: "SharpFM*"
+          # Narrowed to the versioned archive pattern: SharpFM-v{tag}-{target}.{tar.gz|zip}.
+          # The previous "SharpFM*" glob also matched SharpFM.sln at the
+          # repo root, which three parallel matrix runners then raced to
+          # upload, producing "Not Found" errors on the update endpoint.
+          files: "SharpFM-*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The `SharpFM*` glob in `softprops/action-gh-release` was matching `SharpFM.sln` at the repo root alongside the intended `SharpFM-v*-<target>.tar.gz` / `.zip` archives.
- Three parallel matrix runners each uploaded the solution file; with `overwrite_files: true` one won and the others got `Not Found` on the asset update endpoint, failing the Publish step of the v2.0.0-beta.1 release ([run 24751164358](https://github.com/fuzzzerd/SharpFM/actions/runs/24751164358)).
- Tightened the glob to `SharpFM-*` (hyphen) so only the versioned release archives match.

## Test plan
- [x] Re-run the Publish-Release-To-Artifacts workflow against v2.0.0-beta.1 and confirm the three target archives upload cleanly.
- [x] Verify `SharpFM.sln` is no longer listed as a release asset.