### PR TITLE
fix(deps): unblock dependabot nuget updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     MicrosoftCodeAnalysis:
       patterns:
         - "Microsoft.CodeAnalysis.*"
+- package-ecosystem: "nuget"
+  directory: "/.config"
+  schedule:
+    interval: "daily"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.104",
-    "rollForward": "latestFeature"
+    "version": "10.0.100",
+    "rollForward": "latestMinor"
   }
 }

--- a/src/SharpFM.Plugin/SharpFM.Plugin.csproj
+++ b/src/SharpFM.Plugin/SharpFM.Plugin.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="MinVer" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/SharpFM.Plugin.Tests/SharpFM.Plugin.Tests.csproj
+++ b/tests/SharpFM.Plugin.Tests/SharpFM.Plugin.Tests.csproj
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Pin `Microsoft.Extensions.Logging[.Abstractions]` from `10.0.*` to `10.0.7` in `SharpFM.Plugin` and `SharpFM.Plugin.Tests` — floating wildcards interact badly with dependabot's NuGet updater.
- Loosen `global.json` to `version: 10.0.100` with `rollForward: latestMinor`, so any .NET 10 SDK satisfies the pin (prior `latestFeature` only matched the `10.0.1xx` band).
- Add a dedicated `nuget` entry targeting `/.config` so `dotnet-tools.json` (xamlstyler.console) gets its own update job and isn't blocked by sln-level restore issues.

Motivation: no nuget dependabot PRs have opened since February 2025. The github_actions ecosystem runs daily and is healthy; nuget wasn't being dispatched at all.