### PR TITLE
refactor: adopt central package management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,32 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Avalonia" Version="11.2.4" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.2.4" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.4" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.4" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.4" />
+    <PackageVersion Include="Avalonia.Xaml.Interactions" Version="11.2.0.8" />
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
+    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.1.0" />
+    <PackageVersion Include="TextMateSharp.Grammars" Version="1.0.66" />
+    <PackageVersion Include="FluentAvaloniaUI" Version="2.2.0" />
+
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+
+    <PackageVersion Include="NLog" Version="5.4.0" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="5.4.0" />
+
+    <PackageVersion Include="MinVer" Version="6.0.0" />
+
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/SharpFM.Plugin.Sample/SharpFM.Plugin.Sample.csproj
+++ b/src/SharpFM.Plugin.Sample/SharpFM.Plugin.Sample.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.4" />
-    <PackageReference Include="FluentAvaloniaUI" Version="2.2.0" />
-    <PackageReference Include="MinVer" Version="6.0.0">
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="FluentAvaloniaUI" />
+    <PackageReference Include="MinVer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/SharpFM.Plugin.UI/SharpFM.Plugin.UI.csproj
+++ b/src/SharpFM.Plugin.UI/SharpFM.Plugin.UI.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.4" />
-    <PackageReference Include="MinVer" Version="6.0.0">
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="MinVer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/SharpFM.Plugin.XmlViewer/SharpFM.Plugin.XmlViewer.csproj
+++ b/src/SharpFM.Plugin.XmlViewer/SharpFM.Plugin.XmlViewer.csproj
@@ -16,13 +16,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.4" />
-    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
-    <PackageReference Include="TextMateSharp.Grammars" Version="1.0.66" />
-    <PackageReference Include="AvaloniaEdit.TextMate" Version="11.1.0" />
-    <PackageReference Include="FluentAvaloniaUI" Version="2.2.0" />
-    <PackageReference Include="MinVer" Version="6.0.0">
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="Avalonia.AvaloniaEdit" />
+    <PackageReference Include="TextMateSharp.Grammars" />
+    <PackageReference Include="AvaloniaEdit.TextMate" />
+    <PackageReference Include="FluentAvaloniaUI" />
+    <PackageReference Include="MinVer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/SharpFM.Plugin/SharpFM.Plugin.csproj
+++ b/src/SharpFM.Plugin/SharpFM.Plugin.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageReference Include="MinVer" Version="6.0.0">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="MinVer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/SharpFM/SharpFM.csproj
+++ b/src/SharpFM/SharpFM.csproj
@@ -54,30 +54,29 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
 
-    <PackageReference Include="Avalonia" Version="11.2.4" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.4" />
-    <PackageReference Include="Avalonia.Xaml.Interactions" Version="11.2.0.8" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.4" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.4" />
-    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
-    <PackageReference Include="TextMateSharp.Grammars" Version="1.0.66" />
-    <PackageReference Include="AvaloniaEdit.TextMate" Version="11.1.0" />
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Xaml.Interactions" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="Avalonia.Fonts.Inter" />
+    <PackageReference Include="Avalonia.AvaloniaEdit" />
+    <PackageReference Include="TextMateSharp.Grammars" />
+    <PackageReference Include="AvaloniaEdit.TextMate" />
     <!--Condition
     below is needed to remove Avalonia.Diagnostics package from build output in Release
     configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics"
-      Version="11.2.4" />
-    <PackageReference Include="FluentAvaloniaUI" Version="2.2.0" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
+    <PackageReference Include="FluentAvaloniaUI" />
 
-    <PackageReference Include="MinVer" Version="6.0.0">
+    <PackageReference Include="MinVer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="NLog" Version="5.4.0" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
+    <PackageReference Include="NLog" />
+    <PackageReference Include="NLog.Extensions.Logging" />
 
     <None Update="nlog.config" CopyToOutputDirectory="Always" />
   </ItemGroup>

--- a/tests/SharpFM.Plugin.Tests/SharpFM.Plugin.Tests.csproj
+++ b/tests/SharpFM.Plugin.Tests/SharpFM.Plugin.Tests.csproj
@@ -10,17 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SharpFM.Tests/SharpFM.Tests.csproj
+++ b/tests/SharpFM.Tests/SharpFM.Tests.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Add `Directory.Packages.props` at the repo root with `ManagePackageVersionsCentrally` and a `PackageVersion` entry for every nuget dependency.
- Strip the `Version=` attribute from every `PackageReference` across all 8 csproj files; asset metadata (`IncludeAssets` / `PrivateAssets` / `Condition`) is preserved.
- Single place to update any package version; eliminates the existing Avalonia version drift where `Avalonia.AvaloniaEdit` / `AvaloniaEdit.TextMate` were pinned at 11.1.0 while the rest of the Avalonia stack was at 11.2.4.
- Dependabot's NuGet updater has first-class support for `Directory.Packages.props`, so future bumps touch one file instead of several.