### PR TITLE
feat: upgrade to Avalonia 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -326,6 +326,5 @@ ASALocalRun/
 # NVidia Nsight GPU debugger configuration file
 *.nvuser
 
-# MFractors (Xamarin productivity tool) working folder 
+# MFractors (Xamarin productivity tool) working folder
 .mfractor/
-.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+.claude/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,15 +4,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.4" />
-    <PackageVersion Include="Avalonia.Xaml.Interactions" Version="11.2.0.8" />
-    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
-    <PackageVersion Include="AvaloniaEdit.TextMate" Version="11.1.0" />
-    <PackageVersion Include="TextMateSharp.Grammars" Version="1.0.66" />
+    <PackageVersion Include="Avalonia" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+    <!-- Diagnostics is Debug-only. No 12.x release exists; 11.3.14 is the last maintained
+         version and restores cleanly alongside Avalonia 12.0.1. -->
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Xaml.Interactions" Version="11.3.0.6" />
+    <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
+    <PackageVersion Include="AvaloniaEdit.TextMate" Version="12.0.0" />
+    <PackageVersion Include="TextMateSharp.Grammars" Version="2.0.3" />
     <PackageVersion Include="FluentAvaloniaUI" Version="2.2.0" />
 
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Xaml.Interactions" Version="11.3.0.6" />
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="AvaloniaEdit.TextMate" Version="12.0.0" />
     <PackageVersion Include="TextMateSharp.Grammars" Version="2.0.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,6 @@
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="AvaloniaEdit.TextMate" Version="12.0.0" />
     <PackageVersion Include="TextMateSharp.Grammars" Version="2.0.3" />
-    <PackageVersion Include="FluentAvaloniaUI" Version="2.2.0" />
 
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,6 @@
     <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.1" />
-    <!-- Diagnostics is Debug-only. No 12.x release exists; 11.3.14 is the last maintained
-         version and restores cleanly alongside Avalonia 12.0.1. -->
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.14" />
     <PackageVersion Include="Avalonia.Xaml.Interactions" Version="11.3.0.6" />
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="AvaloniaEdit.TextMate" Version="12.0.0" />

--- a/src/SharpFM.Plugin.Sample/SharpFM.Plugin.Sample.csproj
+++ b/src/SharpFM.Plugin.Sample/SharpFM.Plugin.Sample.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
-    <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="MinVer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/SharpFM.Plugin.XmlViewer/SharpFM.Plugin.XmlViewer.csproj
+++ b/src/SharpFM.Plugin.XmlViewer/SharpFM.Plugin.XmlViewer.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Avalonia.AvaloniaEdit" />
     <PackageReference Include="TextMateSharp.Grammars" />
     <PackageReference Include="AvaloniaEdit.TextMate" />
-    <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="MinVer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/SharpFM/Services/ClipboardService.cs
+++ b/src/SharpFM/Services/ClipboardService.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Input;
-using FluentAvalonia.UI.Data;
+using Avalonia.Input.Platform;
 
 namespace SharpFM.Services;
 
@@ -19,31 +20,35 @@ public class ClipboardService : IClipboardService
 
     public async Task SetTextAsync(string text)
     {
-        var clipboard = _window.Clipboard
-            ?? throw new InvalidOperationException("Clipboard is not available.");
+        var clipboard = GetClipboard();
         await clipboard.SetTextAsync(text);
     }
 
     public async Task SetDataAsync(string format, byte[] data)
     {
-        var clipboard = _window.Clipboard
-            ?? throw new InvalidOperationException("Clipboard is not available.");
-        var dp = new DataPackage();
-        dp.SetData(format, data);
-        await clipboard.SetDataObjectAsync(dp);
+        var clipboard = GetClipboard();
+        var dataFormat = DataFormat.CreateBytesPlatformFormat(format);
+        var transfer = new DataTransfer();
+        transfer.Add(DataTransferItem.Create(dataFormat, data));
+        await clipboard.SetDataAsync(transfer);
     }
 
     public async Task<string[]> GetFormatsAsync()
     {
-        var clipboard = _window.Clipboard
-            ?? throw new InvalidOperationException("Clipboard is not available.");
-        return await clipboard.GetFormatsAsync();
+        var clipboard = GetClipboard();
+        var formats = await clipboard.GetDataFormatsAsync();
+        return formats.Select(f => f.Identifier).ToArray();
     }
 
     public async Task<object?> GetDataAsync(string format)
     {
-        var clipboard = _window.Clipboard
-            ?? throw new InvalidOperationException("Clipboard is not available.");
-        return await clipboard.GetDataAsync(format);
+        var clipboard = GetClipboard();
+        using var transfer = await clipboard.TryGetDataAsync();
+        if (transfer is null) return null;
+        var dataFormat = DataFormat.CreateBytesPlatformFormat(format);
+        return await transfer.TryGetValueAsync(dataFormat);
     }
+
+    private IClipboard GetClipboard() =>
+        _window.Clipboard ?? throw new InvalidOperationException("Clipboard is not available.");
 }

--- a/src/SharpFM/SharpFM.csproj
+++ b/src/SharpFM/SharpFM.csproj
@@ -57,6 +57,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
 
     <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Xaml.Interactions" />
     <PackageReference Include="Avalonia.Themes.Fluent" />

--- a/src/SharpFM/SharpFM.csproj
+++ b/src/SharpFM/SharpFM.csproj
@@ -64,7 +64,6 @@
     <PackageReference Include="Avalonia.AvaloniaEdit" />
     <PackageReference Include="TextMateSharp.Grammars" />
     <PackageReference Include="AvaloniaEdit.TextMate" />
-    <PackageReference Include="FluentAvaloniaUI" />
 
     <PackageReference Include="MinVer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SharpFM/SharpFM.csproj
+++ b/src/SharpFM/SharpFM.csproj
@@ -59,7 +59,6 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Controls.DataGrid" />
     <PackageReference Include="Avalonia.Desktop" />
-    <PackageReference Include="Avalonia.Xaml.Interactions" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
     <PackageReference Include="Avalonia.AvaloniaEdit" />

--- a/src/SharpFM/SharpFM.csproj
+++ b/src/SharpFM/SharpFM.csproj
@@ -65,10 +65,6 @@
     <PackageReference Include="Avalonia.AvaloniaEdit" />
     <PackageReference Include="TextMateSharp.Grammars" />
     <PackageReference Include="AvaloniaEdit.TextMate" />
-    <!--Condition
-    below is needed to remove Avalonia.Diagnostics package from build output in Release
-    configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
     <PackageReference Include="FluentAvaloniaUI" />
 
     <PackageReference Include="MinVer">


### PR DESCRIPTION
Bumps Avalonia core from 11.2.4 to 12.0.1 and ports the one place the new API broke us (clipboard).

## Changes

- **`Directory.Packages.props`** — Avalonia / Avalonia.Desktop / Avalonia.Themes.Fluent / Avalonia.Fonts.Inter → 12.0.1; Avalonia.AvaloniaEdit / AvaloniaEdit.TextMate → 12.0.0; TextMateSharp.Grammars → 2.0.3.
- **`Avalonia.Controls.DataGrid` pinned to 12.0.0** — a stale 11.1.0 was coming in transitively via AvaloniaEdit and couldn't parse v12 bindings, which took out `TableEditorControl.axaml`. Adding an explicit top-level reference forces the correct version.
- **`ClipboardService.cs`** rewritten against the new clipboard API:
  - `SetTextAsync` is now `ClipboardExtensions.SetTextAsync` (extension on `IClipboard`, requires `using Avalonia.Input.Platform`).
  - `SetDataObjectAsync(IDataObject)` is gone; replacement is a `DataTransfer` containing a `DataTransferItem.Create(DataFormat.CreateBytesPlatformFormat(format), bytes)` passed to `IClipboard.SetDataAsync(IAsyncDataTransfer)`.
  - `GetFormatsAsync()` is now `ClipboardExtensions.GetDataFormatsAsync()` and returns `DataFormat[]`; we project `.Identifier` to keep `IClipboardService`'s `string[]` shape so no callers change.
  - `GetDataAsync(format)` is now `clipboard.TryGetDataAsync()` returning a disposable `IAsyncDataTransfer`; we wrap it in `using` and pull the typed value with `TryGetValueAsync(DataFormat.CreateBytesPlatformFormat(format))`.
  - `IClipboardService`'s public shape is unchanged, so `MainWindowViewModel` and `RawClipboardWindow` didn't need changes.
- **`Avalonia.Diagnostics` dropped entirely.** Avalonia 12 removed in-process F12 DevTools. The replacement bridge (`AvaloniaUI.DiagnosticsSupport` + an external AvaloniaUI Developer Tools desktop app) requires a paid license. The previous `Avalonia.Diagnostics 11.3.14` restored alongside 12.0.1 core but crashes at runtime when F12 attaches. Rather than ship a dead F12 binding or adopt a paid tool, the package is removed.
- **`Avalonia.Xaml.Interactions` dropped.** No XAML or C# in the codebase referenced it.
- **`FluentAvaloniaUI` dropped.** The only usage was one helper class (`DataPackage`) in the clipboard copy path, which Avalonia 12's `DataTransferItem` replaces directly. None of FluentAvaloniaUI's controls were ever used; it had been unused from the moment of the ClipboardService rewrite above.

## Why the clipboard API changed (upstream context)

Avalonia PR #20521 replaced the `IDataObject` + `string` model with an async-first, typed, multi-item model:

- Platform clipboards (Win32 / NSPasteboard / Wayland) are natively async; the old wrappers faked sync.
- Raw `string` format identifiers gave no guidance on platform-vs-application-vs-in-process scoping. The new `DataFormat` type makes that explicit and typed (`DataFormat<byte[]>`, `DataFormat<string>`, etc.).
- Real clipboards hold multiple items with multiple format representations each; `IDataObject` flattened that to one blob.

"AS IS" passthrough semantics are preserved for platform-specific formats (`CreateBytesPlatformFormat`), which is what SharpFM needs for FileMaker's `Mac-XM*` types.