### PR TITLE
fix: remove Delete key shortcut for clip deletion

### DIFF
--- a/src/SharpFM/MainWindow.axaml
+++ b/src/SharpFM/MainWindow.axaml
@@ -22,7 +22,6 @@
         <KeyBinding Gesture="Ctrl+N" Command="{Binding NewScriptCommand}" />
         <KeyBinding Gesture="Ctrl+Shift+N" Command="{Binding NewTableCommand}" />
         <KeyBinding Gesture="Ctrl+Shift+C" Command="{Binding CopySelectedToClip}" />
-        <KeyBinding Gesture="Delete" Command="{Binding DeleteSelectedClip}" />
     </Window.KeyBindings>
 
     <DockPanel>
@@ -44,7 +43,7 @@
                 <Separator />
                 <MenuItem Command="{Binding CopyAsClass}" Header="Copy as C# Class" />
                 <Separator />
-                <MenuItem Command="{Binding DeleteSelectedClip}" Header="Delete Clip" InputGesture="Delete" />
+                <MenuItem Command="{Binding DeleteSelectedClip}" Header="Delete Clip" />
             </MenuItem>
             <MenuItem Header="_Tools">
                 <MenuItem x:Name="rawClipboardMenuItem" Header="Raw Clipboard Viewer..." />


### PR DESCRIPTION
## Summary

Fixes #158.

The Window-level `<KeyBinding Gesture="Delete" Command="{Binding DeleteSelectedClip}" />` fired regardless of focus, so pressing Delete inside the script editor (or any text field) deleted the entire clip the user was editing rather than a character. Real data-loss risk.

Removed the global keybinding and the corresponding `InputGesture="Delete"` hint from the Edit menu item. Clip deletion remains reachable via the Edit menu and the clip-list context menu — keyboard shortcut intentionally not replaced, since destructive actions shouldn't be triggerable by a bare key.