### PR TITLE
feat: add Ctrl+V shortcut for FileMaker paste

### DIFF
--- a/src/SharpFM/MainWindow.axaml
+++ b/src/SharpFM/MainWindow.axaml
@@ -22,6 +22,7 @@
         <KeyBinding Gesture="Ctrl+N" Command="{Binding NewScriptCommand}" />
         <KeyBinding Gesture="Ctrl+Shift+N" Command="{Binding NewTableCommand}" />
         <KeyBinding Gesture="Ctrl+Shift+C" Command="{Binding CopySelectedToClip}" />
+        <KeyBinding Gesture="Ctrl+V" Command="{Binding PasteFileMakerClipData}" />
     </Window.KeyBindings>
 
     <DockPanel>

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -230,6 +230,7 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         {
             var formats = await _clipboard.GetFormatsAsync();
             int count = 0;
+            ClipViewModel? lastAdded = null;
 
             foreach (var format in formats.Where(f => f.StartsWith("Mac-", StringComparison.CurrentCultureIgnoreCase)).Distinct())
             {
@@ -244,8 +245,14 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
                 // don't add duplicates
                 if (FileMakerClips.Any(k => k.Clip.XmlData == clip.XmlData)) continue;
 
-                FileMakerClips.Add(new ClipViewModel(clip));
+                lastAdded = new ClipViewModel(clip);
+                FileMakerClips.Add(lastAdded);
                 count++;
+            }
+
+            if (lastAdded is not null)
+            {
+                SelectedClip = lastAdded;
             }
 
             ShowStatus(count > 0 ? $"Pasted {count} clip(s) from FileMaker" : "No FileMaker clips found on clipboard");

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Microsoft.Extensions.Logging;
@@ -21,7 +23,7 @@ public class MockClipboardService : IClipboardService
 
     public Task SetTextAsync(string text) { LastText = text; return Task.CompletedTask; }
     public Task SetDataAsync(string format, byte[] data) { LastFormat = format; LastData = data; return Task.CompletedTask; }
-    public Task<string[]> GetFormatsAsync() => Task.FromResult(Array.Empty<string>());
+    public Task<string[]> GetFormatsAsync() => Task.FromResult(ClipboardData.Keys.ToArray());
     public Task<object?> GetDataAsync(string format) =>
         Task.FromResult(ClipboardData.TryGetValue(format, out var v) ? v : null);
 }
@@ -111,6 +113,29 @@ public class MainWindowViewModelTests
         var vm = CreateVm(clipboard);
         await vm.PasteFileMakerClipData();
         Assert.Contains("No FileMaker clips found", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task PasteFileMakerClipData_SelectsLastPastedClip()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSC"] = BuildClipBytes("<fmxmlsnippet><Script name=\"FirstPasted\"></Script></fmxmlsnippet>");
+        clipboard.ClipboardData["Mac-XMSS"] = BuildClipBytes("<fmxmlsnippet><Step name=\"SecondPasted\"></Step></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        var initialCount = vm.FileMakerClips.Count;
+
+        await vm.PasteFileMakerClipData();
+
+        Assert.NotNull(vm.SelectedClip);
+        Assert.Equal(initialCount + 2, vm.FileMakerClips.Count);
+        Assert.Same(vm.FileMakerClips[^1], vm.SelectedClip);
+        Assert.Contains("Pasted 2 clip(s)", vm.StatusMessage);
+    }
+
+    private static byte[] BuildClipBytes(string xml)
+    {
+        var payload = Encoding.UTF8.GetBytes(xml);
+        return BitConverter.GetBytes(payload.Length).Concat(payload).ToArray();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The Edit menu has long advertised Ctrl+V for "Paste from FileMaker" via `InputGesture`, but no actual KeyBinding existed, so the shortcut didn't fire. Bind it at the Window level. Avalonia processes the focused control's KeyDown first and only routes to the Window's KeyBindings when the event is unhandled — so text inputs (`TextBox`, AvaloniaEdit `TextEditor`) keep their normal Ctrl+V text-paste, and the shortcut only fires when focus is outside an editable field.

`PasteFileMakerClipData` already gracefully no-ops with a "No FileMaker clips found on clipboard" status when the clipboard contains no `Mac-*` formats, so misfires are harmless.

Also auto-select the most recently pasted clip so the editor opens to it and the list scrolls to it (Avalonia's `ListBox.AutoScrollToSelectedItem` is on by default). Before this, a successful paste appended the clip to the bottom of the list with no visual confirmation.

`MockClipboardService.GetFormatsAsync` was hardcoded to return `Array.Empty<string>()`, which made paste-related tests impossible. Now it surfaces the keys held in `ClipboardData` — small change that unblocks the new test.