### PR TITLE
feat: tree browser and VS Code-style tabs for clips

### DIFF
--- a/src/SharpFM.Model/ClipData.cs
+++ b/src/SharpFM.Model/ClipData.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SharpFM.Model;
 
 /// <summary>
@@ -7,4 +9,13 @@ namespace SharpFM.Model;
 /// <param name="Name">Clip display name (filename without extension for file-based storage).</param>
 /// <param name="ClipType">Clipboard format identifier (e.g. "Mac-XMSS").</param>
 /// <param name="Xml">Raw XML content of the clip.</param>
-public record ClipData(string Name, string ClipType, string Xml);
+public record ClipData(string Name, string ClipType, string Xml)
+{
+    /// <summary>
+    /// Hierarchy the clip lives under, as an ordered list of folder segment
+    /// names. Empty = root. Segments are plain strings (no slashes); each
+    /// repository implementation decides how to map them to its storage
+    /// (subdirectories, record columns, URL path, etc.).
+    /// </summary>
+    public IReadOnlyList<string> FolderPath { get; init; } = [];
+}

--- a/src/SharpFM/Editors/ClipEditorViewFactory.cs
+++ b/src/SharpFM/Editors/ClipEditorViewFactory.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using Avalonia.Controls;
+using Avalonia.Media;
+using AvaloniaEdit;
+using AvaloniaEdit.Highlighting;
+using SharpFM.Schema.Editor;
+
+namespace SharpFM.Editors;
+
+/// <summary>
+/// Builds the Avalonia control used to edit a given clip. Kept centralised so
+/// the clip view-model can cache a single control instance per clip — tab
+/// switches reparent that control rather than reconstructing it, which
+/// matters because <see cref="ScriptTextEditor"/> installs TextMate on
+/// construction and that is expensive.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public static class ClipEditorViewFactory
+{
+    private static readonly FontFamily MonoFont =
+        new("Cascadia Code,Consolas,Menlo,Monospace");
+
+    public static Control Create(IClipEditor editor) => editor switch
+    {
+        ScriptClipEditor s => new ScriptTextEditor
+        {
+            FontFamily = MonoFont,
+            ShowLineNumbers = true,
+            WordWrap = false,
+            DataContext = s,
+        },
+        TableClipEditor t => new TableEditorControl
+        {
+            DataContext = t.ViewModel,
+        },
+        FallbackXmlEditor f => new TextEditor
+        {
+            FontFamily = MonoFont,
+            ShowLineNumbers = true,
+            WordWrap = false,
+            Document = f.Document,
+            SyntaxHighlighting = HighlightingManager.Instance.GetDefinition("Xml"),
+        },
+        _ => new TextBlock { Text = "No editor available for this clip type." },
+    };
+}

--- a/src/SharpFM/Editors/ScriptTextEditor.cs
+++ b/src/SharpFM/Editors/ScriptTextEditor.cs
@@ -19,21 +19,28 @@ namespace SharpFM.Editors;
 /// DataContext is expected to be a <see cref="ScriptClipEditor"/>.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class ScriptTextEditor : TextEditor
+public class ScriptTextEditor : TextEditor, IDisposable
 {
     // Avalonia 12 matches styles by exact type. Without this, a subclass of
     // TextEditor gets no control template and renders blank — the editor's
     // TextArea/TextView visual tree is never built.
     protected override Type StyleKeyOverride => typeof(TextEditor);
 
+    // Shared across every script editor in the process. Building RegistryOptions
+    // pulls bundled themes into memory; doing that once (and reusing the result)
+    // measurably improves the hitch on first tab realisation for new clips.
+    private static readonly RegistryOptions SharedRegistry =
+        new((ThemeName)(int)ThemeName.DarkPlus);
+
+    private static readonly FmScriptRegistryOptions SharedFmRegistry =
+        new(SharedRegistry);
+
     private readonly TextMate.Installation _textMate;
     private readonly ScriptEditorController _controller;
 
     public ScriptTextEditor()
     {
-        var registry = new RegistryOptions((ThemeName)(int)ThemeName.DarkPlus);
-        var fmScriptRegistry = new FmScriptRegistryOptions(registry);
-        _textMate = this.InstallTextMate(fmScriptRegistry);
+        _textMate = this.InstallTextMate(SharedFmRegistry);
         _textMate.SetGrammar(FmScriptRegistryOptions.ScopeName);
 
         _controller = new ScriptEditorController(this);
@@ -50,10 +57,17 @@ public class ScriptTextEditor : TextEditor
         _controller.AttachClipEditor(clipEditor);
     }
 
-    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
-    {
-        base.OnDetachedFromVisualTree(e);
+    // Intentionally no dispose-on-detach. Tab switches reparent this control
+    // many times; tearing down TextMate on each detach would force a full
+    // grammar/theme reinstall on every reattach. Lifetime is owned by the
+    // ClipViewModel, which calls <see cref="Dispose"/> when the clip is
+    // removed or its editor is replaced.
 
+    private bool _disposed;
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
         _controller.StatusMessageRaised -= OnStatusMessageRaised;
         _controller.Dispose();
         _textMate.Dispose();

--- a/src/SharpFM/MainWindow.axaml
+++ b/src/SharpFM/MainWindow.axaml
@@ -138,16 +138,20 @@
                                     Text="{Binding SearchText}" />
                             </StackPanel>
 
-                            <!-- Clips list section -->
+                            <!-- Clips tree section. Mirrors the repository's folder
+                                 hierarchy (ClipViewModel.FolderPath). Single-tap a
+                                 clip for a preview tab, double-tap for a permanent
+                                 tab. -->
                             <StackPanel Spacing="8">
-                                <TextBlock 
+                                <TextBlock
                                     Classes="Fluent2Subtitle"
                                     Text="Available Clips" />
-                                <ListBox
-                                    Classes="Fluent2"
-                                    ItemsSource="{Binding FilteredClips}"
-                                    SelectedItem="{Binding SelectedClip}">
-                                    <ListBox.ContextMenu>
+                                <TreeView
+                                    x:Name="clipsTreeView"
+                                    ItemsSource="{Binding RootNodes}"
+                                    Tapped="ClipsTree_Tapped"
+                                    DoubleTapped="ClipsTree_DoubleTapped">
+                                    <TreeView.ContextMenu>
                                         <ContextMenu>
                                             <MenuItem
                                                 Command="{Binding CopySelectedToClip}"
@@ -166,27 +170,28 @@
                                                 Command="{Binding DeleteSelectedClip}"
                                                 Header="Delete Clip" />
                                         </ContextMenu>
-                                    </ListBox.ContextMenu>
-                                    <ListBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <Border 
-                                                CornerRadius="4"
-                                                Padding="12">
-                                                <StackPanel Spacing="4">
-                                                    <TextBox
-                                                        Classes="Fluent2"
-                                                        Text="{Binding Clip.Name, Mode=TwoWay}"
-                                                        Watermark="Clip name" />
+                                    </TreeView.ContextMenu>
+                                    <TreeView.DataTemplates>
+                                        <TreeDataTemplate DataType="vm:ClipTreeNodeViewModel" ItemsSource="{Binding Children}">
+                                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                                <TextBlock
+                                                    FontWeight="SemiBold"
+                                                    IsVisible="{Binding IsFolder}"
+                                                    Text="{Binding Name}" />
+                                                <StackPanel
+                                                    Orientation="Horizontal"
+                                                    Spacing="6"
+                                                    IsVisible="{Binding IsClip}">
+                                                    <TextBlock Text="{Binding Clip.Clip.Name}" />
                                                     <TextBlock
                                                         Classes="Fluent2Caption"
-                                                        MaxLines="1"
-                                                        Opacity="0.7"
-                                                        Text="{Binding ClipTypeDisplay}" />
+                                                        Opacity="0.6"
+                                                        Text="{Binding Clip.ClipTypeDisplay}" />
                                                 </StackPanel>
-                                            </Border>
-                                        </DataTemplate>
-                                    </ListBox.ItemTemplate>
-                                </ListBox>
+                                            </StackPanel>
+                                        </TreeDataTemplate>
+                                    </TreeView.DataTemplates>
+                                </TreeView>
                             </StackPanel>
                         </StackPanel>
                     </ScrollViewer>
@@ -207,40 +212,103 @@
                         <ColumnDefinition Width="0" />
                     </Grid.ColumnDefinitions>
 
-                    <!-- Code editor with Fluent 2 surface treatment. The editor is
-                         selected by the runtime type of ClipViewModel.Editor: no
-                         binding resolves through a null SelectedClip, and no editor
-                         instance exists when no clip is selected. -->
+                    <!-- Open clips area: VS Code-style tab strip. Each tab wraps
+                         a ClipViewModel; the tab header italicizes for preview
+                         tabs and shows a dirty dot when the clip has unsaved
+                         edits. The tab body reuses the existing per-editor
+                         DataTemplates. -->
                     <Border
                         Grid.Column="0"
                         Classes="Fluent2SurfaceElevated">
-                        <ContentControl Content="{Binding SelectedClip}">
-                            <ContentControl.DataTemplates>
-                                <DataTemplate DataType="vm:ClipViewModel">
-                                    <ContentControl Content="{Binding Editor}">
-                                        <ContentControl.DataTemplates>
-                                            <DataTemplate DataType="editors:ScriptClipEditor">
-                                                <editors:ScriptTextEditor
-                                                    FontFamily="Cascadia Code,Consolas,Menlo,Monospace"
-                                                    ShowLineNumbers="True"
-                                                    WordWrap="False" />
-                                            </DataTemplate>
-                                            <DataTemplate DataType="editors:TableClipEditor">
-                                                <schema:TableEditorControl DataContext="{Binding ViewModel}" />
-                                            </DataTemplate>
-                                            <DataTemplate DataType="editors:FallbackXmlEditor">
-                                                <AvaloniaEdit:TextEditor
-                                                    FontFamily="Cascadia Code,Consolas,Menlo,Monospace"
-                                                    ShowLineNumbers="True"
-                                                    SyntaxHighlighting="Xml"
-                                                    WordWrap="False"
-                                                    Document="{Binding Document}" />
-                                            </DataTemplate>
-                                        </ContentControl.DataTemplates>
-                                    </ContentControl>
-                                </DataTemplate>
-                            </ContentControl.DataTemplates>
-                        </ContentControl>
+                        <Grid>
+                            <TextBlock
+                                Classes="Fluent2Caption"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Opacity="0.6"
+                                IsVisible="{Binding !OpenTabs.Tabs.Count}"
+                                Text="Single-tap a clip to preview, double-tap to open." />
+
+                            <!-- TabStrip for headers; a separate ItemsControl
+                                 realises every open editor into the visual tree
+                                 once and toggles IsVisible per tab. This avoids
+                                 reparenting AvaloniaEdit on each switch, which
+                                 triggers costly layout/tokenise passes. -->
+                                <DockPanel IsVisible="{Binding OpenTabs.Tabs.Count}">
+                                <TabStrip
+                                    x:Name="openTabStrip"
+                                    DockPanel.Dock="Top"
+                                    ItemsSource="{Binding OpenTabs.Tabs}"
+                                    SelectedItem="{Binding OpenTabs.ActiveTab, Mode=TwoWay}">
+                                    <TabStrip.Styles>
+                                        <Style Selector="TabStripItem">
+                                            <Setter Property="FontSize" Value="14" />
+                                            <Setter Property="MinHeight" Value="32" />
+                                            <Setter Property="Padding" Value="12,6" />
+                                            <Setter Property="Margin" Value="0,0,2,0" />
+                                            <Setter Property="CornerRadius" Value="4,4,0,0" />
+                                            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}" />
+                                            <Setter Property="BorderThickness" Value="1,1,1,0" />
+                                            <Setter Property="BorderBrush" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}" />
+                                            <Setter Property="Opacity" Value="0.75" />
+                                        </Style>
+                                        <Style Selector="TabStripItem:pointerover">
+                                            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumBrush}" />
+                                            <Setter Property="Opacity" Value="1" />
+                                        </Style>
+                                        <Style Selector="TabStripItem:selected">
+                                            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
+                                            <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColorBrush}" />
+                                            <Setter Property="BorderThickness" Value="1,2,1,0" />
+                                            <Setter Property="Opacity" Value="1" />
+                                            <Setter Property="FontWeight" Value="SemiBold" />
+                                        </Style>
+                                    </TabStrip.Styles>
+                                    <TabStrip.ItemTemplate>
+                                        <DataTemplate DataType="vm:OpenTabViewModel">
+                                            <StackPanel Orientation="Horizontal" Spacing="8" DoubleTapped="TabHeader_DoubleTapped">
+                                                <TextBlock
+                                                    VerticalAlignment="Center"
+                                                    FontSize="14"
+                                                    MaxWidth="200"
+                                                    TextTrimming="CharacterEllipsis"
+                                                    ToolTip.Tip="{Binding Title}"
+                                                    FontStyle="{Binding TitleFontStyle}"
+                                                    Text="{Binding Title}" />
+                                                <Ellipse
+                                                    Width="6" Height="6"
+                                                    VerticalAlignment="Center"
+                                                    Fill="{DynamicResource SystemAccentColorBrush}"
+                                                    IsVisible="{Binding IsDirty}" />
+                                                <Button
+                                                    Padding="4,0"
+                                                    FontSize="12"
+                                                    Background="Transparent"
+                                                    BorderThickness="0"
+                                                    Content="✕"
+                                                    Click="CloseTab_Click"
+                                                    Tag="{Binding}" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </TabStrip.ItemTemplate>
+                                </TabStrip>
+                                <ItemsControl
+                                    ItemsSource="{Binding OpenTabs.Tabs}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <Grid />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="vm:OpenTabViewModel">
+                                            <ContentControl
+                                                Content="{Binding Clip.EditorView}"
+                                                IsVisible="{Binding IsActive}" />
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </DockPanel>
+                        </Grid>
                     </Border>
 
                     <!-- Plugin panel splitter -->

--- a/src/SharpFM/MainWindow.axaml.cs
+++ b/src/SharpFM/MainWindow.axaml.cs
@@ -194,4 +194,53 @@ public partial class MainWindow : Window
         window.Configure(_pluginService, _pluginHost, vm, _pluginConfigService);
         window.ShowDialog(this);
     }
+
+    // --- Tree / tab interaction ---
+
+    // Walk the visual tree up from the tapped item to find the clip node that
+    // was hit. TreeView raises Tapped with e.Source pointing at the innermost
+    // text/border; we need the DataContext of the enclosing TreeViewItem.
+    private static ClipTreeNodeViewModel? FindClipNode(object? source)
+    {
+        var current = source as Control;
+        while (current is not null)
+        {
+            if (current is TreeViewItem tvi && tvi.DataContext is ClipTreeNodeViewModel node)
+                return node;
+            if (current.DataContext is ClipTreeNodeViewModel d)
+                return d;
+            current = current.Parent as Control;
+        }
+        return null;
+    }
+
+    private void ClipsTree_Tapped(object? sender, TappedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        var node = FindClipNode(e.Source);
+        if (node?.Clip is null) return;
+        vm.OpenClipAsPreview(node.Clip);
+    }
+
+    private void ClipsTree_DoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        var node = FindClipNode(e.Source);
+        if (node?.Clip is null) return;
+        vm.OpenClipAsPermanent(node.Clip);
+    }
+
+    private void TabHeader_DoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        if ((sender as Control)?.DataContext is OpenTabViewModel tab)
+            vm.OpenTabs.Graduate(tab);
+    }
+
+    private void CloseTab_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        if ((sender as Button)?.Tag is OpenTabViewModel tab)
+            vm.OpenTabs.Close(tab);
+    }
 }

--- a/src/SharpFM/Models/ClipRepository.cs
+++ b/src/SharpFM/Models/ClipRepository.cs
@@ -9,7 +9,9 @@ using SharpFM.Model;
 namespace SharpFM.Models;
 
 /// <summary>
-/// File-system-based clip repository. Stores each clip as a file in a directory.
+/// File-system-based clip repository. Stores each clip as a file in a directory
+/// tree. Subdirectories map one-to-one to <see cref="ClipData.FolderPath"/>
+/// segments.
 /// </summary>
 public class ClipRepository : IClipRepository
 {
@@ -39,17 +41,24 @@ public class ClipRepository : IClipRepository
     public Task<IReadOnlyList<ClipData>> LoadClipsAsync()
     {
         var clips = new List<ClipData>();
+        var root = new DirectoryInfo(ClipPath);
 
-        foreach (var clipFile in Directory.EnumerateFiles(ClipPath))
+        foreach (var clipFile in Directory.EnumerateFiles(ClipPath, "*", SearchOption.AllDirectories))
         {
             try
             {
                 var fi = new FileInfo(clipFile);
+                if (string.IsNullOrEmpty(fi.Extension)) continue;
+
+                var folderPath = GetRelativeFolderSegments(root.FullName, fi.Directory!.FullName);
 
                 clips.Add(new ClipData(
-                    Name: fi.Name.Replace(fi.Extension, string.Empty),
-                    ClipType: fi.Extension.Replace(".", string.Empty),
-                    Xml: File.ReadAllText(clipFile)));
+                    Name: Path.GetFileNameWithoutExtension(fi.Name),
+                    ClipType: fi.Extension.TrimStart('.'),
+                    Xml: File.ReadAllText(clipFile))
+                {
+                    FolderPath = folderPath,
+                });
             }
             catch (Exception ex)
             {
@@ -62,22 +71,43 @@ public class ClipRepository : IClipRepository
 
     public Task SaveClipsAsync(IReadOnlyList<ClipData> clips)
     {
+        var activeRelativePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var clip in clips)
         {
-            var clipPath = Path.Combine(ClipPath, $"{clip.Name}.{clip.ClipType}");
+            var safeSegments = SanitizeFolderPath(clip.FolderPath);
+            var targetDir = safeSegments.Count == 0
+                ? ClipPath
+                : Path.Combine(new[] { ClipPath }.Concat(safeSegments).ToArray());
+
+            Directory.CreateDirectory(targetDir);
+
+            var fileName = $"{clip.Name}.{clip.ClipType}";
+            var clipPath = Path.Combine(targetDir, fileName);
             File.WriteAllText(clipPath, clip.Xml);
+
+            var relative = Path.GetRelativePath(ClipPath, clipPath);
+            activeRelativePaths.Add(relative);
         }
 
-        // Remove files for clips that no longer exist
-        var activeNames = new HashSet<string>(
-            clips.Select(c => $"{c.Name}.{c.ClipType}"),
-            StringComparer.OrdinalIgnoreCase);
-
-        foreach (var file in Directory.EnumerateFiles(ClipPath))
+        // Remove files for clips that no longer exist (anywhere in the tree).
+        foreach (var file in Directory.EnumerateFiles(ClipPath, "*", SearchOption.AllDirectories))
         {
-            if (!activeNames.Contains(Path.GetFileName(file)))
+            var relative = Path.GetRelativePath(ClipPath, file);
+            if (!activeRelativePaths.Contains(relative))
             {
                 File.Delete(file);
+            }
+        }
+
+        // Clean up any now-empty subdirectories (bottom-up).
+        foreach (var dir in Directory.EnumerateDirectories(ClipPath, "*", SearchOption.AllDirectories)
+            .OrderByDescending(d => d.Length))
+        {
+            if (!Directory.EnumerateFileSystemEntries(dir).Any())
+            {
+                try { Directory.Delete(dir); }
+                catch (IOException) { /* best-effort */ }
             }
         }
 
@@ -89,5 +119,29 @@ public class ClipRepository : IClipRepository
         // File-based repo doesn't handle its own location picking.
         // The host manages folder selection and creates a new ClipRepository.
         return Task.FromResult<string?>(null);
+    }
+
+    private static IReadOnlyList<string> GetRelativeFolderSegments(string root, string directory)
+    {
+        var rel = Path.GetRelativePath(root, directory);
+        if (string.IsNullOrEmpty(rel) || rel == ".") return [];
+        return rel.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+            StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    // Reject traversal/rooted segments; repositories are logical stores and
+    // must not escape their root no matter what a misbehaving provider sends.
+    private static IReadOnlyList<string> SanitizeFolderPath(IReadOnlyList<string> segments)
+    {
+        if (segments is null || segments.Count == 0) return [];
+        var safe = new List<string>(segments.Count);
+        foreach (var raw in segments)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) continue;
+            if (raw == "." || raw == "..") continue;
+            if (raw.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0) continue;
+            safe.Add(raw);
+        }
+        return safe;
     }
 }

--- a/src/SharpFM/Scripting/Editor/FmScriptRegistryOptions.cs
+++ b/src/SharpFM/Scripting/Editor/FmScriptRegistryOptions.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
+using System.Threading;
 using TextMateSharp.Grammars;
 using TextMateSharp.Internal.Grammars.Reader;
 using TextMateSharp.Internal.Types;
@@ -17,6 +19,12 @@ public class FmScriptRegistryOptions : IRegistryOptions
 
     private readonly RegistryOptions _inner;
 
+    // The embedded .tmLanguage.json is immutable; parsing it is not free. Cache
+    // the parsed grammar once per process so repeated TextMate installs (e.g.
+    // fresh script-editor instances) don't reparse ~KB of JSON each time.
+    private static readonly Lazy<IRawGrammar> CachedGrammar =
+        new(LoadFmScriptGrammar, LazyThreadSafetyMode.ExecutionAndPublication);
+
     public FmScriptRegistryOptions(RegistryOptions inner)
     {
         _inner = inner;
@@ -31,7 +39,7 @@ public class FmScriptRegistryOptions : IRegistryOptions
     public IRawGrammar GetGrammar(string scopeName)
     {
         if (scopeName == ScopeName)
-            return LoadFmScriptGrammar();
+            return CachedGrammar.Value;
 
         return _inner.GetGrammar(scopeName);
     }

--- a/src/SharpFM/ViewModels/ClipTreeNodeViewModel.cs
+++ b/src/SharpFM/ViewModels/ClipTreeNodeViewModel.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace SharpFM.ViewModels;
+
+/// <summary>
+/// Node in the left-panel clip tree. A node is either a folder (with children)
+/// or a clip leaf (wrapping a <see cref="ClipViewModel"/>). The tree mirrors
+/// the <c>FolderPath</c> hierarchy exposed by the active repository.
+/// </summary>
+public class ClipTreeNodeViewModel : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    /// <summary>Display name for this node (folder segment or clip name).</summary>
+    public string Name { get; }
+
+    /// <summary>Null when this is a folder node; non-null when a clip leaf.</summary>
+    public ClipViewModel? Clip { get; }
+
+    public bool IsFolder => Clip is null;
+    public bool IsClip => Clip is not null;
+
+    public ObservableCollection<ClipTreeNodeViewModel> Children { get; } = [];
+
+    private bool _isExpanded = true;
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set { if (_isExpanded == value) return; _isExpanded = value; NotifyPropertyChanged(); }
+    }
+
+    private ClipTreeNodeViewModel(string name, ClipViewModel? clip)
+    {
+        Name = name;
+        Clip = clip;
+    }
+
+    public static ClipTreeNodeViewModel Folder(string name) => new(name, null);
+    public static ClipTreeNodeViewModel ClipLeaf(ClipViewModel clip) => new(clip.Clip.Name, clip);
+
+    /// <summary>
+    /// Build a set of root-level nodes from a flat clip collection. Clips are
+    /// grouped by <see cref="ClipViewModel.FolderPath"/>. Folders are sorted
+    /// alphabetically and listed before clip leaves at each level; clip leaves
+    /// are sorted by name for stable display.
+    /// </summary>
+    /// <param name="clips">Flat clip collection.</param>
+    /// <param name="searchText">Optional filter. When non-empty, only clips
+    /// whose names contain the text survive (case-insensitive); folders survive
+    /// when they have any surviving descendant, and matching folders are
+    /// auto-expanded.</param>
+    public static IReadOnlyList<ClipTreeNodeViewModel> Build(
+        IEnumerable<ClipViewModel> clips,
+        string searchText = "")
+    {
+        var rootFolders = new Dictionary<string, ClipTreeNodeViewModel>(StringComparer.OrdinalIgnoreCase);
+        var rootLeaves = new List<ClipTreeNodeViewModel>();
+        var filter = string.IsNullOrEmpty(searchText) ? null : searchText;
+
+        foreach (var clip in clips)
+        {
+            var matches = filter is null ||
+                clip.Clip.Name.Contains(filter, StringComparison.OrdinalIgnoreCase);
+
+            if (clip.FolderPath is { Count: > 0 })
+            {
+                var head = clip.FolderPath[0];
+                if (!rootFolders.TryGetValue(head, out var folder))
+                {
+                    folder = Folder(head);
+                    rootFolders.Add(head, folder);
+                }
+
+                InsertClipIntoFolder(folder, clip, clip.FolderPath, 1, matches, filter is not null);
+            }
+            else if (matches)
+            {
+                rootLeaves.Add(ClipLeaf(clip));
+            }
+        }
+
+        // Drop folders that end up empty after filtering.
+        var folderList = rootFolders.Values
+            .Where(f => HasAnyDescendant(f))
+            .OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        foreach (var f in folderList) SortRecursive(f);
+
+        rootLeaves.Sort((a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.Name, b.Name));
+
+        var result = new List<ClipTreeNodeViewModel>(folderList.Count + rootLeaves.Count);
+        result.AddRange(folderList);
+        result.AddRange(rootLeaves);
+        return result;
+    }
+
+    private static void InsertClipIntoFolder(
+        ClipTreeNodeViewModel folder,
+        ClipViewModel clip,
+        IReadOnlyList<string> path,
+        int depth,
+        bool matches,
+        bool filtering)
+    {
+        if (depth >= path.Count)
+        {
+            if (matches) folder.Children.Add(ClipLeaf(clip));
+            if (filtering && matches) folder.IsExpanded = true;
+            return;
+        }
+
+        var segment = path[depth];
+        var child = folder.Children.FirstOrDefault(c => c.IsFolder &&
+            string.Equals(c.Name, segment, StringComparison.OrdinalIgnoreCase));
+        if (child is null)
+        {
+            child = Folder(segment);
+            folder.Children.Add(child);
+        }
+
+        InsertClipIntoFolder(child, clip, path, depth + 1, matches, filtering);
+
+        if (filtering && HasAnyDescendant(child))
+            folder.IsExpanded = true;
+    }
+
+    private static bool HasAnyDescendant(ClipTreeNodeViewModel node)
+    {
+        foreach (var c in node.Children)
+        {
+            if (c.IsClip) return true;
+            if (HasAnyDescendant(c)) return true;
+        }
+        return false;
+    }
+
+    private static void SortRecursive(ClipTreeNodeViewModel node)
+    {
+        if (!node.IsFolder || node.Children.Count == 0) return;
+
+        var folders = node.Children.Where(c => c.IsFolder)
+            .OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase).ToList();
+        var leaves = node.Children.Where(c => c.IsClip)
+            .OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase).ToList();
+
+        node.Children.Clear();
+        foreach (var f in folders) { node.Children.Add(f); SortRecursive(f); }
+        foreach (var l in leaves) node.Children.Add(l);
+    }
+}

--- a/src/SharpFM/ViewModels/ClipViewModel.cs
+++ b/src/SharpFM/ViewModels/ClipViewModel.cs
@@ -1,13 +1,16 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Avalonia.Controls;
 using AvaloniaEdit.Document;
 using SharpFM.Editors;
+using SharpFM.Model;
 using SharpFM.Schema.Editor;
 
 namespace SharpFM.ViewModels;
 
-public partial class ClipViewModel : INotifyPropertyChanged
+public partial class ClipViewModel : INotifyPropertyChanged, IDisposable
 {
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -25,15 +28,42 @@ public partial class ClipViewModel : INotifyPropertyChanged
     public IClipEditor Editor { get; private set; }
 
     /// <summary>
+    /// Hierarchy the clip lives under in its repository. Matches
+    /// <see cref="ClipData.FolderPath"/> — empty list means "root".
+    /// </summary>
+    public IReadOnlyList<string> FolderPath { get; set; } = [];
+
+    /// <summary>
     /// Fires when the editor content changes due to user edits (debounced).
     /// </summary>
     public event EventHandler? EditorContentChanged;
+
+    /// <summary>
+    /// Snapshot of the editor's XML the last time the clip was known to be
+    /// persisted. Used to compute <see cref="IsDirty"/>.
+    /// </summary>
+    private string _savedXml;
 
     public ClipViewModel(FileMakerClip clip)
     {
         Clip = clip;
         Editor = CreateEditor(clip.XmlData);
         Editor.ContentChanged += OnEditorContentChanged;
+        _savedXml = Editor.ToXml();
+    }
+
+    // The Avalonia control that renders this clip. Cached so tab switches
+    // reparent the same control instead of reconstructing a ScriptTextEditor
+    // (and re-running its TextMate install) on every switch. Lazily built on
+    // first access.
+    private Control? _editorView;
+    public Control EditorView => _editorView ??= ClipEditorViewFactory.Create(Editor);
+
+    public void Dispose()
+    {
+        Editor.ContentChanged -= OnEditorContentChanged;
+        if (_editorView is IDisposable d) d.Dispose();
+        _editorView = null;
     }
 
     /// <summary>
@@ -48,11 +78,40 @@ public partial class ClipViewModel : INotifyPropertyChanged
         Editor = CreateEditor(xml);
         Editor.ContentChanged += OnEditorContentChanged;
 
+        // The cached editor view was built around the old editor instance.
+        // Tear it down so the next EditorView access rebuilds cleanly.
+        if (_editorView is IDisposable d) d.Dispose();
+        _editorView = null;
+
+        // Reverse sync from plugins / external tools must not flag the clip
+        // dirty — the source of truth is what the editor now holds.
+        _savedXml = Editor.ToXml();
+        NotifyPropertyChanged(nameof(IsDirty));
+
         NotifyPropertyChanged(nameof(Editor));
+        NotifyPropertyChanged(nameof(EditorView));
         NotifyPropertyChanged(nameof(ScriptDocument));
         NotifyPropertyChanged(nameof(TableEditor));
         NotifyPropertyChanged(nameof(XmlDocument));
     }
+
+    /// <summary>
+    /// Called by the host after a successful save; captures the current XML as
+    /// the "clean" baseline so edits that follow light the dirty indicator.
+    /// </summary>
+    public void MarkSaved()
+    {
+        _savedXml = Editor.ToXml();
+        NotifyPropertyChanged(nameof(IsDirty));
+    }
+
+    /// <summary>
+    /// True when the editor's current XML differs from the last saved snapshot.
+    /// Drives the dirty dot on open tabs. Computed on demand — cheap enough
+    /// for a UI binding evaluated only when <c>ContentChanged</c> fires.
+    /// </summary>
+    public bool IsDirty =>
+        !string.Equals(Editor.ToXml(), _savedXml, StringComparison.Ordinal);
 
     private IClipEditor CreateEditor(string? xml) => Clip.ClipboardFormat switch
     {
@@ -61,9 +120,16 @@ public partial class ClipViewModel : INotifyPropertyChanged
         _ => new FallbackXmlEditor(xml),
     };
 
-    private void OnEditorContentChanged(object? sender, EventArgs e)
+    private void OnEditorContentChanged(object? sender, EventArgs e) =>
+        HandleEditorContentChanged();
+
+    // Exposed to the test assembly (InternalsVisibleTo SharpFM.Tests) so tests
+    // can drive the post-debounce path without standing up an Avalonia
+    // Dispatcher. In production this is invoked from Editor.ContentChanged.
+    internal void HandleEditorContentChanged()
     {
         Clip.XmlData = Editor.ToXml();
+        NotifyPropertyChanged(nameof(IsDirty));
         EditorContentChanged?.Invoke(this, EventArgs.Empty);
     }
 

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -26,6 +26,13 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
     private readonly IFolderService _folderService;
     private readonly DispatcherTimer _statusTimer;
     private IClipRepository _repository;
+    private OpenTabViewModel? _trackedActiveTab;
+
+    private void OnActiveTabPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(OpenTabViewModel.Clip))
+            NotifyPropertyChanged(nameof(SelectedClip));
+    }
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -56,15 +63,45 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
             path2: Path.Join("SharpFM", "Clips")
         );
 
+        OpenTabs = new OpenTabsViewModel();
+        OpenTabs.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != nameof(OpenTabsViewModel.ActiveTab)) return;
+
+            // Re-subscribe to the new active tab so preview-slot clip swaps
+            // also surface as SelectedClip changes (the tab instance stays
+            // the same, but Clip changes underneath).
+            if (_trackedActiveTab is not null)
+                _trackedActiveTab.PropertyChanged -= OnActiveTabPropertyChanged;
+            _trackedActiveTab = OpenTabs.ActiveTab;
+            if (_trackedActiveTab is not null)
+                _trackedActiveTab.PropertyChanged += OnActiveTabPropertyChanged;
+
+            NotifyPropertyChanged(nameof(SelectedClip));
+        };
+
+        RootNodes = [];
+
         FileMakerClips = [];
         FileMakerClips.CollectionChanged += (sender, e) =>
         {
-            // reset search text, which will trigger a property notify changed
-            // that will re-run the search with empty value (which shows all)
-            SearchText = string.Empty;
-        };
+            // A flat-list change invalidates the tree; rebuilding respects the
+            // current search filter.
+            RebuildTree();
 
-        FilteredClips = [];
+            // When a clip is removed from the catalog (e.g., DeleteSelectedClip),
+            // close any tabs that still point at it and dispose the cached
+            // editor view so resources (e.g. TextMate installation) don't leak.
+            if (e.OldItems is not null)
+            {
+                foreach (var item in e.OldItems)
+                {
+                    if (item is not ClipViewModel vm) continue;
+                    OpenTabs.CloseClip(vm);
+                    vm.Dispose();
+                }
+            }
+        };
 
         _repository = new ClipRepository(_currentPath);
         LoadClipsFromRepository();
@@ -75,26 +112,33 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
     private void LoadClipsFromRepository()
     {
         var clips = _repository.LoadClipsAsync().GetAwaiter().GetResult();
-
-        FileMakerClips.Clear();
-
-        foreach (var clip in clips)
-        {
-            FileMakerClips.Add(new ClipViewModel(
-                new FileMakerClip(clip.Name, clip.ClipType, clip.Xml)));
-        }
+        PopulateClips(clips);
     }
 
     private async Task LoadClipsFromRepositoryAsync()
     {
         var clips = await _repository.LoadClipsAsync();
+        PopulateClips(clips);
+    }
 
+    private void PopulateClips(IReadOnlyList<ClipData> clips)
+    {
+        // Closing the tab strip first keeps the editor area from holding refs
+        // to clips that are about to be replaced.
+        OpenTabs.Tabs.Clear();
+        OpenTabs.ActiveTab = null;
+
+        // Clear fires CollectionChanged with Reset (no OldItems), so dispose
+        // the outgoing clips explicitly.
+        foreach (var c in FileMakerClips) c.Dispose();
         FileMakerClips.Clear();
-
         foreach (var clip in clips)
         {
             FileMakerClips.Add(new ClipViewModel(
-                new FileMakerClip(clip.Name, clip.ClipType, clip.Xml)));
+                new FileMakerClip(clip.Name, clip.ClipType, clip.Xml))
+            {
+                FolderPath = clip.FolderPath,
+            });
         }
     }
 
@@ -131,10 +175,17 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
                 clip.Clip.XmlData = clip.Editor.ToXml();
 
             var clipData = FileMakerClips
-                .Select(c => new ClipData(c.Clip.Name, c.ClipType, c.Clip.XmlData))
+                .Select(c => new ClipData(c.Clip.Name, c.ClipType, c.Clip.XmlData)
+                {
+                    FolderPath = c.FolderPath,
+                })
                 .ToList();
 
             await _repository.SaveClipsAsync(clipData);
+
+            // Clip is now known-persisted — rebase the dirty snapshot so the
+            // tab dirty dots clear.
+            foreach (var c in FileMakerClips) c.MarkSaved();
 
             ShowStatus($"Saved {clipData.Count} clip(s) to {_repository.CurrentLocation}");
         }
@@ -173,9 +224,9 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        var name = SelectedClip.Clip.Name;
         var clip = SelectedClip;
-        SelectedClip = null;
+        var name = clip.Clip.Name;
+        OpenTabs.CloseClip(clip);
         FileMakerClips.Remove(clip);
         ShowStatus($"Deleted clip '{name}'");
     }
@@ -393,19 +444,43 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
 
     public ObservableCollection<ClipViewModel> FileMakerClips { get; set; }
 
-    public ObservableCollection<ClipViewModel> FilteredClips { get; set; }
+    /// <summary>
+    /// VS Code-style open tabs — the right-side editor area binds to this.
+    /// </summary>
+    public OpenTabsViewModel OpenTabs { get; }
 
-    private ClipViewModel? _selectedClip;
+    /// <summary>
+    /// Tree nodes shown in the left-side clip browser. Rebuilt whenever
+    /// <see cref="FileMakerClips"/> or <see cref="SearchText"/> changes.
+    /// </summary>
+    public ObservableCollection<ClipTreeNodeViewModel> RootNodes { get; set; }
+
+    /// <summary>
+    /// The clip backing the active tab, if any. Kept as a property so existing
+    /// commands (copy/paste/delete) and tests that reasoned about a single
+    /// "current" clip continue to work with the tabbed UI.
+    /// </summary>
     public ClipViewModel? SelectedClip
     {
-        get => _selectedClip;
+        get => OpenTabs.ActiveTab?.Clip;
         set
         {
-            _selectedClip = value;
             StatusMessage = "";
+            if (value is null) { OpenTabs.ActiveTab = null; NotifyPropertyChanged(); return; }
+            OpenTabs.OpenAsPermanent(value);
             NotifyPropertyChanged();
         }
     }
+
+    /// <summary>
+    /// Open a clip as a preview tab (single-click in the tree).
+    /// </summary>
+    public void OpenClipAsPreview(ClipViewModel clip) => OpenTabs.OpenAsPreview(clip);
+
+    /// <summary>
+    /// Open a clip as a permanent tab (double-click in the tree).
+    /// </summary>
+    public void OpenClipAsPermanent(ClipViewModel clip) => OpenTabs.OpenAsPermanent(clip);
 
     private string _searchText = string.Empty;
     public string SearchText
@@ -414,17 +489,16 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         set
         {
             _searchText = value;
-            var previousSelection = _selectedClip;
-            FilteredClips.Clear();
-            foreach (var c in FileMakerClips.Where(c => c.Clip.Name.Contains(_searchText, StringComparison.OrdinalIgnoreCase)))
-            {
-                FilteredClips.Add(c);
-            }
-            // Preserve selection if still visible in filtered results
-            if (previousSelection != null && FilteredClips.Contains(previousSelection))
-                SelectedClip = previousSelection;
+            RebuildTree();
             NotifyPropertyChanged();
         }
+    }
+
+    private void RebuildTree()
+    {
+        var nodes = ClipTreeNodeViewModel.Build(FileMakerClips, _searchText);
+        RootNodes.Clear();
+        foreach (var n in nodes) RootNodes.Add(n);
     }
 
     private string _currentPath;

--- a/src/SharpFM/ViewModels/OpenTabViewModel.cs
+++ b/src/SharpFM/ViewModels/OpenTabViewModel.cs
@@ -1,0 +1,92 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Avalonia.Media;
+
+namespace SharpFM.ViewModels;
+
+/// <summary>
+/// A single open clip tab. Wraps a <see cref="ClipViewModel"/> and carries
+/// tab-specific state (preview vs permanent). Dirty state is read through to
+/// <see cref="ClipViewModel.IsDirty"/>.
+/// </summary>
+public class OpenTabViewModel : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    private ClipViewModel _clip;
+    public ClipViewModel Clip
+    {
+        get => _clip;
+        set
+        {
+            if (ReferenceEquals(_clip, value)) return;
+
+            if (_clip is not null)
+                _clip.PropertyChanged -= OnClipPropertyChanged;
+
+            _clip = value;
+            _clip.PropertyChanged += OnClipPropertyChanged;
+
+            NotifyPropertyChanged();
+            NotifyPropertyChanged(nameof(Title));
+            NotifyPropertyChanged(nameof(IsDirty));
+        }
+    }
+
+    private bool _isPreview;
+    /// <summary>
+    /// True when this tab was opened via single-click (VS Code "preview"). A
+    /// preview tab graduates to permanent on double-click of its header or on
+    /// the first edit to its clip.
+    /// </summary>
+    public bool IsPreview
+    {
+        get => _isPreview;
+        set
+        {
+            if (_isPreview == value) return;
+            _isPreview = value;
+            NotifyPropertyChanged();
+            NotifyPropertyChanged(nameof(TitleFontStyle));
+        }
+    }
+
+    public string Title => _clip.Clip.Name;
+
+    /// <summary>
+    /// Italic while previewing, normal once graduated. Avalonia doesn't
+    /// evaluate data triggers, so the VM computes the style directly.
+    /// </summary>
+    public FontStyle TitleFontStyle => _isPreview ? FontStyle.Italic : FontStyle.Normal;
+
+    public bool IsDirty => _clip.IsDirty;
+
+    private bool _isActive;
+    /// <summary>
+    /// Whether this tab is the currently active (visible) one. Driven by
+    /// <see cref="OpenTabsViewModel.ActiveTab"/>; bound to the tab content's
+    /// <c>IsVisible</c> so every realised editor stays in the visual tree
+    /// and switching is a visibility toggle rather than a reparent.
+    /// </summary>
+    public bool IsActive
+    {
+        get => _isActive;
+        internal set { if (_isActive == value) return; _isActive = value; NotifyPropertyChanged(); }
+    }
+
+    public OpenTabViewModel(ClipViewModel clip, bool isPreview)
+    {
+        _clip = clip;
+        _isPreview = isPreview;
+        _clip.PropertyChanged += OnClipPropertyChanged;
+    }
+
+    private void OnClipPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ClipViewModel.IsDirty))
+            NotifyPropertyChanged(nameof(IsDirty));
+    }
+}

--- a/src/SharpFM/ViewModels/OpenTabsViewModel.cs
+++ b/src/SharpFM/ViewModels/OpenTabsViewModel.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace SharpFM.ViewModels;
+
+/// <summary>
+/// Collection of VS Code-style document tabs shown in the main editor area.
+/// Implements preview/permanent semantics:
+/// <list type="bullet">
+/// <item>Single-click in the tree calls <see cref="OpenAsPreview"/>: reuses a
+/// single "preview" tab slot if one exists, otherwise creates a new italic
+/// tab.</item>
+/// <item>Double-click in the tree calls <see cref="OpenAsPermanent"/>: opens
+/// a non-italic, sticky tab.</item>
+/// <item>Double-tapping a preview tab header, or editing its clip, graduates
+/// the preview to a permanent tab (<see cref="GraduateActive"/>).</item>
+/// </list>
+/// </summary>
+public class OpenTabsViewModel : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    public ObservableCollection<OpenTabViewModel> Tabs { get; } = [];
+
+    private OpenTabViewModel? _activeTab;
+    public OpenTabViewModel? ActiveTab
+    {
+        get => _activeTab;
+        set
+        {
+            if (ReferenceEquals(_activeTab, value)) return;
+            if (_activeTab is not null) _activeTab.IsActive = false;
+            _activeTab = value;
+            if (_activeTab is not null) _activeTab.IsActive = true;
+            NotifyPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// The lone preview tab, if any. A tab leaves this slot when it graduates
+    /// to permanent or is closed.
+    /// </summary>
+    public OpenTabViewModel? PreviewTab { get; private set; }
+
+    /// <summary>
+    /// Open a clip in the preview slot. If the clip is already open (preview
+    /// or permanent) its tab is activated; otherwise the preview slot is
+    /// reused — or created if absent.
+    /// </summary>
+    public OpenTabViewModel OpenAsPreview(ClipViewModel clip)
+    {
+        var existing = Tabs.FirstOrDefault(t => ReferenceEquals(t.Clip, clip));
+        if (existing is not null)
+        {
+            ActiveTab = existing;
+            return existing;
+        }
+
+        if (PreviewTab is not null)
+        {
+            DetachGraduationWatch(PreviewTab);
+            PreviewTab.Clip = clip;
+            AttachGraduationWatch(PreviewTab);
+            ActiveTab = PreviewTab;
+            return PreviewTab;
+        }
+
+        var tab = new OpenTabViewModel(clip, isPreview: true);
+        Tabs.Add(tab);
+        PreviewTab = tab;
+        AttachGraduationWatch(tab);
+        ActiveTab = tab;
+        return tab;
+    }
+
+    /// <summary>
+    /// Open a clip as a permanent tab. If the clip is already in the preview
+    /// slot the preview simply graduates; if it's already open as permanent,
+    /// its tab is activated.
+    /// </summary>
+    public OpenTabViewModel OpenAsPermanent(ClipViewModel clip)
+    {
+        var existing = Tabs.FirstOrDefault(t => ReferenceEquals(t.Clip, clip));
+        if (existing is not null)
+        {
+            if (existing.IsPreview) Graduate(existing);
+            ActiveTab = existing;
+            return existing;
+        }
+
+        var tab = new OpenTabViewModel(clip, isPreview: false);
+        Tabs.Add(tab);
+        ActiveTab = tab;
+        return tab;
+    }
+
+    /// <summary>
+    /// Graduate a preview tab to permanent. No-op if the tab is not a preview.
+    /// </summary>
+    public void Graduate(OpenTabViewModel tab)
+    {
+        if (!tab.IsPreview) return;
+        DetachGraduationWatch(tab);
+        tab.IsPreview = false;
+        if (ReferenceEquals(PreviewTab, tab)) PreviewTab = null;
+    }
+
+    /// <summary>
+    /// Convenience: graduate the currently active tab if it's a preview.
+    /// Called when the user double-taps the active tab header.
+    /// </summary>
+    public void GraduateActive()
+    {
+        if (_activeTab is not null) Graduate(_activeTab);
+    }
+
+    /// <summary>
+    /// Close a tab. If it was the active tab, picks the neighbour (next, else
+    /// previous) as the new active; falls back to null when the last tab is
+    /// closed. Clears the preview slot if the closed tab held it.
+    /// </summary>
+    public void Close(OpenTabViewModel tab)
+    {
+        var idx = Tabs.IndexOf(tab);
+        if (idx < 0) return;
+
+        DetachGraduationWatch(tab);
+        Tabs.RemoveAt(idx);
+        if (ReferenceEquals(PreviewTab, tab)) PreviewTab = null;
+
+        if (ReferenceEquals(_activeTab, tab))
+        {
+            if (Tabs.Count == 0) ActiveTab = null;
+            else if (idx < Tabs.Count) ActiveTab = Tabs[idx];
+            else ActiveTab = Tabs[Tabs.Count - 1];
+        }
+    }
+
+    /// <summary>
+    /// Remove every open tab that points at <paramref name="clip"/>. Used when
+    /// a clip is deleted from the repository so it doesn't linger in the
+    /// editor area.
+    /// </summary>
+    public void CloseClip(ClipViewModel clip)
+    {
+        foreach (var tab in Tabs.Where(t => ReferenceEquals(t.Clip, clip)).ToList())
+            Close(tab);
+    }
+
+    private void AttachGraduationWatch(OpenTabViewModel tab)
+    {
+        tab.Clip.PropertyChanged += OnWatchedClipChanged;
+    }
+
+    private void DetachGraduationWatch(OpenTabViewModel tab)
+    {
+        tab.Clip.PropertyChanged -= OnWatchedClipChanged;
+    }
+
+    private void OnWatchedClipChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // The first user edit graduates a preview tab — VS Code parity.
+        if (e.PropertyName != nameof(ClipViewModel.IsDirty)) return;
+        if (sender is not ClipViewModel clip) return;
+        if (!clip.IsDirty) return;
+
+        var tab = Tabs.FirstOrDefault(t => ReferenceEquals(t.Clip, clip));
+        if (tab is not null && tab.IsPreview) Graduate(tab);
+    }
+}

--- a/tests/SharpFM.Tests/Models/ClipRepositoryTests.cs
+++ b/tests/SharpFM.Tests/Models/ClipRepositoryTests.cs
@@ -168,7 +168,100 @@ public class ClipRepositoryTests
             Assert.Equal("Script", loaded[0].Name);
             Assert.Equal("Mac-XMSS", loaded[0].ClipType);
             Assert.Equal("<xml>data</xml>", loaded[0].Xml);
+            Assert.Empty(loaded[0].FolderPath);
         }
         finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task LoadClipsAsync_Recurses_IntoSubdirectories()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var sub = Path.Combine(dir, "Scripts", "Utilities");
+            Directory.CreateDirectory(sub);
+            File.WriteAllText(Path.Combine(sub, "Log.Mac-XMSS"), "<xml/>");
+            File.WriteAllText(Path.Combine(dir, "RootClip.Mac-XMTB"), "<xml/>");
+
+            var repo = new ClipRepository(dir);
+            var clips = await repo.LoadClipsAsync();
+
+            var nested = Assert.Single(clips, c => c.Name == "Log");
+            Assert.Equal(new[] { "Scripts", "Utilities" }, nested.FolderPath);
+
+            var rooted = Assert.Single(clips, c => c.Name == "RootClip");
+            Assert.Empty(rooted.FolderPath);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveClipsAsync_RoundTripsFolderPath()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            var clips = new List<ClipData>
+            {
+                new("A", "Mac-XMSS", "<a/>") { FolderPath = new[] { "Group1", "Sub" } },
+                new("B", "Mac-XMTB", "<b/>") { FolderPath = Array.Empty<string>() }
+            };
+
+            await repo.SaveClipsAsync(clips);
+            Assert.True(File.Exists(Path.Combine(dir, "Group1", "Sub", "A.Mac-XMSS")));
+            Assert.True(File.Exists(Path.Combine(dir, "B.Mac-XMTB")));
+
+            var loaded = await repo.LoadClipsAsync();
+            var a = Assert.Single(loaded, c => c.Name == "A");
+            Assert.Equal(new[] { "Group1", "Sub" }, a.FolderPath);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveClipsAsync_DeletesOrphans_AcrossSubdirectories()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var sub = Path.Combine(dir, "Old");
+            Directory.CreateDirectory(sub);
+            File.WriteAllText(Path.Combine(sub, "Gone.Mac-XMSS"), "<x/>");
+
+            var repo = new ClipRepository(dir);
+            await repo.SaveClipsAsync([new("Keep", "Mac-XMSS", "<k/>")]);
+
+            Assert.False(File.Exists(Path.Combine(sub, "Gone.Mac-XMSS")));
+            Assert.False(Directory.Exists(sub));
+            Assert.True(File.Exists(Path.Combine(dir, "Keep.Mac-XMSS")));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveClipsAsync_RejectsTraversalSegments()
+    {
+        var dir = CreateTempDir();
+        var sibling = Path.Combine(Path.GetTempPath(), $"sharpfm-sibling-{Guid.NewGuid()}");
+        try
+        {
+            Directory.CreateDirectory(sibling);
+            var repo = new ClipRepository(dir);
+
+            await repo.SaveClipsAsync([new("Evil", "Mac-XMSS", "<x/>")
+                { FolderPath = new[] { "..", Path.GetFileName(sibling) } }]);
+
+            Assert.False(File.Exists(Path.Combine(sibling, "Evil.Mac-XMSS")));
+            // ".." is stripped; any remaining safe segments stay under dir.
+            var written = Directory.EnumerateFiles(dir, "Evil.Mac-XMSS", SearchOption.AllDirectories).Single();
+            Assert.StartsWith(dir, written);
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, true);
+            if (Directory.Exists(sibling)) Directory.Delete(sibling, true);
+        }
     }
 }

--- a/tests/SharpFM.Tests/ViewModels/ClipTreeNodeViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/ClipTreeNodeViewModelTests.cs
@@ -1,0 +1,97 @@
+using System.Linq;
+using SharpFM.Model;
+using SharpFM.ViewModels;
+using Xunit;
+
+namespace SharpFM.Tests.ViewModels;
+
+public class ClipTreeNodeViewModelTests
+{
+    private static ClipViewModel Clip(string name, params string[] folderPath)
+    {
+        var vm = new ClipViewModel(new FileMakerClip(name, "Mac-XMSS",
+            "<fmxmlsnippet type=\"FMObjectList\"></fmxmlsnippet>"));
+        vm.FolderPath = folderPath;
+        return vm;
+    }
+
+    [Fact]
+    public void Build_FlatClips_ProducesRootLeaves()
+    {
+        var clips = new[] { Clip("A"), Clip("B") };
+        var nodes = ClipTreeNodeViewModel.Build(clips);
+
+        Assert.Equal(2, nodes.Count);
+        Assert.All(nodes, n => Assert.True(n.IsClip));
+        Assert.Equal(new[] { "A", "B" }, nodes.Select(n => n.Name));
+    }
+
+    [Fact]
+    public void Build_NestedClips_GroupsUnderFolders()
+    {
+        var clips = new[]
+        {
+            Clip("Top"),
+            Clip("Inner", "Scripts"),
+            Clip("Deep", "Scripts", "Utils")
+        };
+
+        var nodes = ClipTreeNodeViewModel.Build(clips);
+
+        // Folder "Scripts" first (folders before leaves at root).
+        Assert.Equal(2, nodes.Count);
+        var scripts = nodes[0];
+        Assert.True(scripts.IsFolder);
+        Assert.Equal("Scripts", scripts.Name);
+
+        var innerLeaf = scripts.Children.Single(c => c.IsClip);
+        Assert.Equal("Inner", innerLeaf.Name);
+
+        var utils = scripts.Children.Single(c => c.IsFolder);
+        Assert.Equal("Utils", utils.Name);
+        Assert.Equal("Deep", utils.Children.Single().Name);
+
+        Assert.True(nodes[1].IsClip);
+        Assert.Equal("Top", nodes[1].Name);
+    }
+
+    [Fact]
+    public void Build_Search_FiltersClipsAndExpandsMatchingFolders()
+    {
+        var clips = new[]
+        {
+            Clip("Hidden", "Scripts"),
+            Clip("NeedleClip", "Scripts", "Utils"),
+            Clip("RootMatch")
+        };
+
+        var nodes = ClipTreeNodeViewModel.Build(clips, "needle");
+
+        // Hidden clip filtered out; Scripts folder survives because a
+        // descendant matches; its "Utils" subfolder is auto-expanded.
+        var scripts = nodes.Single(n => n.IsFolder);
+        Assert.True(scripts.IsExpanded);
+        var utils = scripts.Children.Single();
+        Assert.True(utils.IsFolder);
+        Assert.True(utils.IsExpanded);
+        Assert.Equal("NeedleClip", utils.Children.Single().Name);
+
+        // Unrelated root clip drops because it doesn't match.
+        Assert.DoesNotContain(nodes, n => n.IsClip && n.Name == "RootMatch");
+    }
+
+    [Fact]
+    public void Build_IsStable_WhenFolderPathCasingDiffers()
+    {
+        var clips = new[]
+        {
+            Clip("A", "Scripts"),
+            Clip("B", "scripts")
+        };
+
+        var nodes = ClipTreeNodeViewModel.Build(clips);
+
+        var folder = Assert.Single(nodes, n => n.IsFolder);
+        Assert.Equal(2, folder.Children.Count);
+    }
+}

--- a/tests/SharpFM.Tests/ViewModels/ClipViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/ClipViewModelTests.cs
@@ -109,4 +109,45 @@ public class ClipViewModelTests
         Assert.Equal("Renamed", vm.Clip.Name);
         Assert.Equal("Name", changed);
     }
+
+    [Fact]
+    public void IsDirty_FalseImmediatelyAfterConstruction()
+    {
+        var vm = CreateScriptClip(WrapXml("<Step enable=\"True\" id=\"93\" name=\"Beep\"/>"));
+        Assert.False(vm.IsDirty);
+    }
+
+    [Fact]
+    public void IsDirty_TrueAfterEditorEdit()
+    {
+        var vm = CreateScriptClip(WrapXml("<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>a</Text></Step>"));
+        vm.ScriptDocument!.Text += "\n# new line";
+
+        // IsDirty is computed live — no need to pump the ContentChanged
+        // debouncer; a UI binding watching IsDirty gets notified when
+        // ContentChanged fires, but the value itself is always fresh.
+        Assert.True(vm.IsDirty);
+    }
+
+    [Fact]
+    public void MarkSaved_ClearsIsDirty()
+    {
+        var vm = CreateScriptClip(WrapXml("<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>a</Text></Step>"));
+        vm.ScriptDocument!.Text += "\n# edited";
+        Assert.True(vm.IsDirty);
+
+        vm.MarkSaved();
+        Assert.False(vm.IsDirty);
+    }
+
+    [Fact]
+    public void ReplaceEditor_ResetsIsDirty()
+    {
+        var vm = CreateScriptClip(WrapXml("<Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>a</Text></Step>"));
+        vm.ScriptDocument!.Text += "\n# edited";
+        Assert.True(vm.IsDirty);
+
+        vm.ReplaceEditor(vm.Editor.ToXml());
+        Assert.False(vm.IsDirty);
+    }
 }

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -175,27 +175,29 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void DeleteSelectedClip_RemovesFromFilteredClips()
+    public void DeleteSelectedClip_RemovesFromCatalogAndTree()
     {
         var vm = CreateVm();
         vm.NewScriptCommand();
         var clip = vm.SelectedClip!;
-        Assert.Contains(clip, vm.FilteredClips);
+        Assert.Contains(clip, vm.FileMakerClips);
+        Assert.Contains(vm.RootNodes, n => n.IsClip && ReferenceEquals(n.Clip, clip));
 
         vm.DeleteSelectedClip();
 
-        Assert.DoesNotContain(clip, vm.FilteredClips);
+        Assert.DoesNotContain(clip, vm.FileMakerClips);
+        Assert.DoesNotContain(vm.RootNodes, n => n.IsClip && ReferenceEquals(n.Clip, clip));
     }
 
     [Fact]
-    public void SearchText_FiltersClips()
+    public void SearchText_FiltersTree()
     {
         var vm = CreateVm();
         vm.NewScriptCommand(); // adds a clip named "New Script"
         vm.SearchText = "zzz_nonexistent";
-        Assert.Empty(vm.FilteredClips);
+        Assert.Empty(vm.RootNodes);
         vm.SearchText = "";
-        Assert.NotEmpty(vm.FilteredClips);
+        Assert.NotEmpty(vm.RootNodes);
     }
 
     [Fact]

--- a/tests/SharpFM.Tests/ViewModels/OpenTabsViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/OpenTabsViewModelTests.cs
@@ -1,0 +1,138 @@
+using SharpFM.Model;
+using SharpFM.ViewModels;
+using Xunit;
+
+namespace SharpFM.Tests.ViewModels;
+
+public class OpenTabsViewModelTests
+{
+    private static ClipViewModel Clip(string name) =>
+        new(new FileMakerClip(name, "Mac-XMSS",
+            "<fmxmlsnippet type=\"FMObjectList\"><Step enable=\"True\" id=\"89\" name=\"# (comment)\"><Text>a</Text></Step></fmxmlsnippet>"));
+
+    [Fact]
+    public void OpenAsPreview_CreatesPreviewTab_FirstTime()
+    {
+        var tabs = new OpenTabsViewModel();
+        var tab = tabs.OpenAsPreview(Clip("A"));
+
+        Assert.True(tab.IsPreview);
+        Assert.Same(tab, tabs.PreviewTab);
+        Assert.Same(tab, tabs.ActiveTab);
+        Assert.Single(tabs.Tabs);
+    }
+
+    [Fact]
+    public void OpenAsPreview_ReusesSlot_WhenAnotherPreviewExists()
+    {
+        var tabs = new OpenTabsViewModel();
+        var first = tabs.OpenAsPreview(Clip("A"));
+        var secondClip = Clip("B");
+
+        var second = tabs.OpenAsPreview(secondClip);
+
+        Assert.Same(first, second); // reused the same tab instance
+        Assert.Same(secondClip, second.Clip);
+        Assert.Single(tabs.Tabs);
+        Assert.True(second.IsPreview);
+    }
+
+    [Fact]
+    public void OpenAsPreview_ActivatesExistingTab_WithoutChangingIt()
+    {
+        var tabs = new OpenTabsViewModel();
+        var clip = Clip("A");
+        var tab = tabs.OpenAsPermanent(clip);
+        tabs.OpenAsPreview(Clip("B")); // another preview, shouldn't affect A
+
+        tabs.OpenAsPreview(clip);
+
+        Assert.Same(tab, tabs.ActiveTab);
+        Assert.False(tab.IsPreview); // still permanent
+    }
+
+    [Fact]
+    public void OpenAsPermanent_GraduatesExistingPreview()
+    {
+        var tabs = new OpenTabsViewModel();
+        var clip = Clip("A");
+        var preview = tabs.OpenAsPreview(clip);
+
+        var promoted = tabs.OpenAsPermanent(clip);
+
+        Assert.Same(preview, promoted);
+        Assert.False(promoted.IsPreview);
+        Assert.Null(tabs.PreviewTab);
+    }
+
+    [Fact]
+    public void GraduateActive_ClearsPreviewFlag()
+    {
+        var tabs = new OpenTabsViewModel();
+        tabs.OpenAsPreview(Clip("A"));
+        tabs.GraduateActive();
+
+        Assert.False(tabs.ActiveTab!.IsPreview);
+        Assert.Null(tabs.PreviewTab);
+    }
+
+    [Fact]
+    public void EditingPreviewClip_GraduatesTab()
+    {
+        var tabs = new OpenTabsViewModel();
+        var clip = Clip("A");
+        var tab = tabs.OpenAsPreview(clip);
+
+        clip.ScriptDocument!.Text += "\n# edited";
+        // The editor's ContentChanged event is debounced via the UI dispatcher;
+        // drive the same handler synchronously for the test.
+        clip.HandleEditorContentChanged();
+
+        Assert.True(clip.IsDirty);
+        Assert.False(tab.IsPreview);
+        Assert.Null(tabs.PreviewTab);
+    }
+
+    [Fact]
+    public void Close_PicksNeighbour_WhenClosingActive()
+    {
+        var tabs = new OpenTabsViewModel();
+        var a = tabs.OpenAsPermanent(Clip("A"));
+        var b = tabs.OpenAsPermanent(Clip("B"));
+        var c = tabs.OpenAsPermanent(Clip("C"));
+
+        tabs.ActiveTab = b;
+        tabs.Close(b);
+
+        Assert.Same(c, tabs.ActiveTab); // next neighbour preferred
+        Assert.DoesNotContain(b, tabs.Tabs);
+
+        tabs.Close(c);
+        Assert.Same(a, tabs.ActiveTab); // falls back to previous when no next
+    }
+
+    [Fact]
+    public void Close_LastTab_NullsActive()
+    {
+        var tabs = new OpenTabsViewModel();
+        var a = tabs.OpenAsPreview(Clip("A"));
+
+        tabs.Close(a);
+
+        Assert.Null(tabs.ActiveTab);
+        Assert.Null(tabs.PreviewTab);
+        Assert.Empty(tabs.Tabs);
+    }
+
+    [Fact]
+    public void CloseClip_RemovesAllTabsForThatClip()
+    {
+        var tabs = new OpenTabsViewModel();
+        var clip = Clip("A");
+        tabs.OpenAsPermanent(clip);
+
+        tabs.CloseClip(clip);
+
+        Assert.Empty(tabs.Tabs);
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the flat clip list with a TreeView that mirrors the repository's folder hierarchy, and the single-clip editor pane with a tab strip that supports VS Code-style preview tabs, permanent tabs, and dirty indicators.

## What's new

- **Repository hierarchy.** `ClipData` gains an optional `FolderPath`; the filesystem `ClipRepository` recurses subdirectories, round-trips folder paths on save, cleans up now-empty subdirs, and rejects traversal segments. The hierarchy concept lives on the repository contract so non-filesystem providers can synthesise folders however they want.
- **TreeView.** Left panel is a `TreeView` bound to a `ClipTreeNodeViewModel` structure built from the flat clip collection. Search filters the tree and auto-expands matching branches. Tree template kept compact with existing Fluent2 styling.
- **Preview/permanent tabs.** Single-tap a clip in the tree → italic preview tab (reuses the one preview slot across further single-taps). Double-tap a clip, double-tap the tab header, or make the first edit → graduates the preview to a permanent tab. Close via the `✕` button; closing the active tab picks a neighbour.
- **Dirty indicator.** `ClipViewModel.IsDirty` compares the live editor XML against a saved snapshot; `MarkSaved()` rebases after a bulk `Ctrl+S`. Tab headers show an accent dot while dirty; it clears on save.

## Performance

Opening the tab-strip naively triggered a visible hitch on every tab switch because `ScriptTextEditor` reinstalls TextMate on construction. Three levers applied:

1. `ScriptTextEditor` no longer tears down TextMate on visual-tree detach; it's now `IDisposable` and is only disposed when its owning `ClipViewModel` is removed.
2. `ClipViewModel` caches its Avalonia editor control (`EditorView`) so tab switches can reparent the same instance instead of reconstructing it.
3. `FmScriptRegistryOptions` caches the parsed FM script grammar; `ScriptTextEditor` shares a single static `RegistryOptions` / `FmScriptRegistryOptions` across instances.
4. Tab contents are realised once into an `ItemsControl` and toggled via `IsVisible`, so switching is a visibility flip rather than a reparent + AvaloniaEdit layout/tokenise pass.

## Notes

- Drag-to-reorder tabs is intentionally out of scope here — built-in `TabStrip` doesn't offer it and pulling in a docking framework was too much churn for this pass. Easy to add later if wanted.
- Plugin panels that listen to `SelectedClip` now also fire when the preview slot swaps its clip in place.

Closes #160