### PR TITLE
perf: gate AvaloniaNLogSink at Warning, cache loggers

### DIFF
--- a/src/SharpFM/AvaloniaNLogSink.cs
+++ b/src/SharpFM/AvaloniaNLogSink.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Avalonia;
 using Avalonia.Logging;
@@ -8,14 +9,38 @@ namespace SharpFM;
 
 /// <summary>
 /// Avalonia Log Sink that writes to NLog Loggers.
+///
+/// <para>Hot path note: Avalonia's framework code emits high-volume
+/// Verbose/Debug/Info events during layout, input, and rendering. The
+/// app's <c>nlog.config</c> blackholes <c>Avalonia*</c> events at those
+/// levels via a <c>final="true"</c> rule, so they have nowhere to go —
+/// but if <see cref="IsEnabled"/> says <c>true</c>, Avalonia still
+/// formats arguments and calls <see cref="Log"/>, which then walks NLog's
+/// rule engine before discarding. Profiling on a small script during
+/// typing showed this sink consuming ~318ms of inclusive CPU over a 30s
+/// trace — more than any other SharpFM-attributed path.</para>
+///
+/// <para>Two-part fix: gate <see cref="IsEnabled"/> at Warning so Avalonia
+/// short-circuits before the formatting work, and cache the per-source
+/// <see cref="ILogger"/> so the surviving events skip
+/// <see cref="LogManager.GetLogger(string)"/> on every call.</para>
 /// </summary>
 [ExcludeFromCodeCoverage]
 public class AvaloniaNLogSink : ILogSink
 {
+    private static readonly ILogger DefaultLogger =
+        LogManager.GetLogger(typeof(AvaloniaNLogSink).ToString());
+
+    private static readonly ConcurrentDictionary<Type, ILogger> LoggerCache = new();
+
     /// <summary>
-    /// AvaloniaNLogSink is always enabled.
+    /// Gate at Warning to match the intent of <c>nlog.config</c>'s
+    /// <c>Avalonia*</c> blackhole rule. Avalonia framework code routinely
+    /// emits hundreds of Verbose/Debug/Info events per second during
+    /// typing — none of which would reach a target anyway.
     /// </summary>
-    public bool IsEnabled(LogEventLevel level, string area) => true;
+    public bool IsEnabled(LogEventLevel level, string area) =>
+        level >= LogEventLevel.Warning;
 
     public void Log(LogEventLevel level, string area, object? source, string messageTemplate)
     {
@@ -24,8 +49,9 @@ public class AvaloniaNLogSink : ILogSink
 
     public void Log(LogEventLevel level, string area, object? source, string messageTemplate, params object?[] propertyValues)
     {
-        ILogger? logger = source is not null ? LogManager.GetLogger(source.GetType().ToString())
-            : LogManager.GetLogger(typeof(AvaloniaNLogSink).ToString());
+        ILogger logger = source is null
+            ? DefaultLogger
+            : LoggerCache.GetOrAdd(source.GetType(), static t => LogManager.GetLogger(t.ToString()));
 
         logger.Log(LogLevelToNLogLevel(level), $"{area}: {messageTemplate}", propertyValues);
     }


### PR DESCRIPTION
## Summary

Avalonia framework code emits high-volume Verbose/Debug/Info events during layout, input, and rendering. `nlog.config` already blackholes `Avalonia*` events at those levels via a `final="true"` rule, so they have nowhere to go — but `AvaloniaNLogSink.IsEnabled` returning `true` unconditionally meant Avalonia still formatted arguments and called `Log()` before NLog discarded the event.

A `dotnet-trace` capture during a script-editor typing session showed this sink consuming ~318ms of inclusive CPU over a 30-second window — more than any other app-attributed path, and a noticeable fraction of UI-thread budget per keystroke.

## Changes

- `IsEnabled` now returns `false` below `Warning`. Avalonia short-circuits before formatting arguments, matching the intent of the existing `Avalonia*` blackhole rule in `nlog.config`.
- Per-source `ILogger` lookups go through a `ConcurrentDictionary<Type, ILogger>` instead of `LogManager.GetLogger(string)` on each call. Smaller win once number1 is in place but cheap enough to land together.

Warning/Error/Fatal events flow through unchanged and still reach the console + logfile targets.