### PR TITLE
fix: dispatch Ctrl+V via tunnel preview so editor paste works

### DIFF
--- a/src/SharpFM/MainWindow.axaml
+++ b/src/SharpFM/MainWindow.axaml
@@ -22,7 +22,10 @@
         <KeyBinding Gesture="Ctrl+N" Command="{Binding NewScriptCommand}" />
         <KeyBinding Gesture="Ctrl+Shift+N" Command="{Binding NewTableCommand}" />
         <KeyBinding Gesture="Ctrl+Shift+C" Command="{Binding CopySelectedToClip}" />
-        <KeyBinding Gesture="Ctrl+V" Command="{Binding PasteFileMakerClipData}" />
+        <!-- Ctrl+V is wired in code-behind via a tunnel-phase preview
+             handler so it can defer to the focused text editor (TextBox /
+             AvaloniaEdit) and only fall through to the FileMaker-clip
+             paste when focus is on the tree, tabs, or window background. -->
     </Window.KeyBindings>
 
     <DockPanel>

--- a/src/SharpFM/MainWindow.axaml.cs
+++ b/src/SharpFM/MainWindow.axaml.cs
@@ -4,6 +4,10 @@ using System.Diagnostics.CodeAnalysis;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using AvaloniaEdit;
+using AvaloniaEdit.Editing;
 using SharpFM.Diagnostics;
 using SharpFM.Plugin;
 using SharpFM.Plugin.UI;
@@ -33,6 +37,9 @@ public partial class MainWindow : Window
         var rawClipboard = this.FindControl<MenuItem>("rawClipboardMenuItem");
         if (rawClipboard != null)
             rawClipboard.Click += (_, _) => new RawClipboardWindow().Show(this);
+
+        // Tunnel-phase Ctrl+V — see OnPreviewKeyDown.
+        AddHandler(KeyDownEvent, OnPreviewKeyDown, RoutingStrategies.Tunnel);
 
         // Wire up plugin UI when DataContext is set
         DataContextChanged += OnDataContextChanged;
@@ -242,5 +249,35 @@ public partial class MainWindow : Window
         if (DataContext is not MainWindowViewModel vm) return;
         if ((sender as Button)?.Tag is OpenTabViewModel tab)
             vm.OpenTabs.Close(tab);
+    }
+
+    // Ctrl+V dispatch (issue #197). A Window-level KeyBinding fires before
+    // the focused control sees the keystroke, which broke plain-text paste
+    // in the script editor and the search box. Bubble-phase OnKeyDown does
+    // the opposite — text editors mark Ctrl+V handled, so the Window never
+    // sees the global case. Tunnel-phase preview lets us inspect the key
+    // first and decide based on focus: hand off to text editors, otherwise
+    // intercept for the FileMaker-clip paste.
+    private void OnPreviewKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.V) return;
+        if (e.KeyModifiers != KeyModifiers.Control) return;
+        if (IsTextInputFocused()) return;
+        if (DataContext is not MainWindowViewModel vm) return;
+
+        e.Handled = true;
+        _ = vm.PasteFileMakerClipData();
+    }
+
+    private bool IsTextInputFocused()
+    {
+        var focused = FocusManager?.GetFocusedElement() as Visual;
+        while (focused is not null)
+        {
+            if (focused is TextBox or TextEditor or TextArea)
+                return true;
+            focused = focused.GetVisualParent();
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

Closes #197.

The Window-level `KeyBinding` for `PasteFileMakerClipData` consumed Ctrl+V before the focused text editor could see it, so plain-text copy/paste inside the script editor and the search box was broken — the global FileMaker-clip paste fired instead.

## Fix

Replaced the XAML `KeyBinding` with a tunnel-phase preview handler in `MainWindow` code-behind. The handler walks the focused element up the visual tree:

- Focus is inside a `TextBox` / `TextEditor` / `TextArea` → no-op, the editor handles Ctrl+V natively.
- Focus is anywhere else (tree, tabs, window background) → consume the key and invoke `vm.PasteFileMakerClipData()`.

Tunnel phase is required because text editors mark Ctrl+V handled in their own `KeyDown`, so a bubble-phase override would never see the global case.

## Why not the alternatives

- **Clipboard-content dispatch** (editors only handle Ctrl+V if clipboard has plain text): clipboard reads are async, and FileMaker writes both `Unicode Text` and `Mac-XMSC` on copy, so this would never disambiguate.
- **Separate shortcut** (e.g., Ctrl+Shift+V for global paste): cleanest design, but a UX change. Left as a future option.

The view concern (focus + routed-event dispatch) stays in code-behind; the action (`PasteFileMakerClipData`) remains in the VM.