### PR TITLE
fix: escape clip name in TableClipStrategy.DefaultXml

### DIFF
--- a/src/SharpFM.Model/ClipTypes/TableClipStrategy.cs
+++ b/src/SharpFM.Model/ClipTypes/TableClipStrategy.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using SharpFM.Model.Parsing;
 using SharpFM.Model.Schema;
+using SharpFM.Model.Scripting;
 
 namespace SharpFM.Model.ClipTypes;
 
@@ -63,6 +64,6 @@ public sealed class TableClipStrategy : IClipTypeStrategy
 
     public string DefaultXml(string clipName) =>
         _wrapsBaseTable
-            ? $"<fmxmlsnippet type=\"FMObjectList\"><BaseTable name=\"{clipName}\"></BaseTable></fmxmlsnippet>"
+            ? $"<fmxmlsnippet type=\"FMObjectList\"><BaseTable name=\"{XmlHelpers.XmlEscape(clipName)}\"></BaseTable></fmxmlsnippet>"
             : "<fmxmlsnippet type=\"FMObjectList\"></fmxmlsnippet>";
 }

--- a/tests/SharpFM.Tests/ClipTypes/TableClipStrategyTests.cs
+++ b/tests/SharpFM.Tests/ClipTypes/TableClipStrategyTests.cs
@@ -69,4 +69,19 @@ public class TableClipStrategyTests
         var result = TableClipStrategy.Table.Parse(seed);
         Assert.IsType<ParseSuccess>(result);
     }
+
+    [Theory]
+    [InlineData("My \"favorite\" stuff")]
+    [InlineData("A & B")]
+    [InlineData("<Angle>")]
+    public void Table_DefaultXml_EscapesPunctuationInName(string clipName)
+    {
+        var seed = TableClipStrategy.Table.DefaultXml(clipName);
+
+        var result = TableClipStrategy.Table.Parse(seed);
+
+        var success = Assert.IsType<ParseSuccess>(result);
+        var model = Assert.IsType<TableClipModel>(success.Model);
+        Assert.Equal(clipName, model.Table.Name);
+    }
 }


### PR DESCRIPTION
## Problem

`TableClipStrategy.DefaultXml` interpolates the clip name straight into the `<BaseTable name="…">` attribute without XML escaping (`src/SharpFM.Model/ClipTypes/TableClipStrategy.cs:66`). A name containing `"`, `&`, `<`, or `>` produces malformed XML; the resulting clip fails to re-parse and is dropped silently. End-users have no way to know punctuation in a name will corrupt their work.

Concrete reproduction: create a table named `My "favorite" stuff`. The generated seed is `<BaseTable name="My "favorite" stuff">` — `Parse` returns `ParseFailure`.

Trust-boundary note: the clipboard is local, so this is data integrity, not a security boundary. The failure mode is silent and hard to diagnose.

## Fix

Wrap `clipName` in `XmlHelpers.XmlEscape` (already in `SharpFM.Model.Scripting`) before interpolation. One-line change.

Audited the sibling strategies — `ScriptClipStrategy`, `LayoutClipStrategy`, `OpaqueClipStrategy` all take `clipName` but ignore it, so no further fixes needed here.

## Tests

`Table_DefaultXml_EscapesPunctuationInName` — theory covering `"`, `&`, and `<>` cases. Asserts the seed round-trips through `Parse` and the resulting `Table.Name` matches the original input. Confirmed RED on master, GREEN with the fix.