### PR TITLE
Plugin-host parse-fidelity API + semantic-validation tier

### DIFF
--- a/src/SharpFM.Model/Clip.cs
+++ b/src/SharpFM.Model/Clip.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using SharpFM.Model.ClipTypes;
 using SharpFM.Model.Parsing;
 using SharpFM.Model.Scripting;
+using SharpFM.Model.Validation;
 
 namespace SharpFM.Model;
 
@@ -99,7 +100,23 @@ public sealed class Clip
             name,
             formatId,
             canonical,
-            () => ClipTypeRegistry.For(formatId).Parse(canonical));
+            () => WithSemanticDiagnostics(formatId, ClipTypeRegistry.For(formatId).Parse(canonical)));
+    }
+
+    private static ClipParseResult WithSemanticDiagnostics(string formatId, ClipParseResult result)
+    {
+        if (result is not ParseSuccess success)
+        {
+            return result;
+        }
+
+        var semantic = SemanticValidatorRegistry.Run(formatId, success.Model);
+        if (semantic.Count == 0)
+        {
+            return success;
+        }
+
+        return success with { Report = success.Report with { SemanticDiagnostics = semantic } };
     }
 
     /// <summary>
@@ -130,20 +147,23 @@ public sealed class Clip
     /// </remarks>
     public static Clip FromEditor(string name, string formatId, string xml, ClipModel model)
     {
-        var report = ReportForEditorModel(model);
+        var report = ReportForEditorModel(formatId, model);
         return new Clip(name, formatId, xml, new ParseSuccess(model, report));
     }
 
-    private static ClipParseReport ReportForEditorModel(ClipModel model)
+    private static ClipParseReport ReportForEditorModel(string formatId, ClipModel model)
     {
-        if (model is ScriptClipModel script)
+        IReadOnlyList<ClipParseDiagnostic> structural = model is ScriptClipModel script
+            ? ClipStrategyHelpers.RawStepDiagnostics(script.Script).ToList()
+            : Array.Empty<ClipParseDiagnostic>();
+        var semantic = SemanticValidatorRegistry.Run(formatId, model);
+
+        if (structural.Count == 0 && semantic.Count == 0)
         {
-            var diagnostics = ClipStrategyHelpers.RawStepDiagnostics(script.Script).ToList();
-            return diagnostics.Count == 0
-                ? ClipParseReport.Empty
-                : new ClipParseReport(diagnostics);
+            return ClipParseReport.Empty;
         }
-        return ClipParseReport.Empty;
+
+        return new ClipParseReport(structural) { SemanticDiagnostics = semantic };
     }
 
     /// <summary>

--- a/src/SharpFM.Model/ClipData.cs
+++ b/src/SharpFM.Model/ClipData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using SharpFM.Model.Parsing;
 
 namespace SharpFM.Model;
 
@@ -18,4 +19,12 @@ public record ClipData(string Name, string ClipType, string Xml)
     /// (subdirectories, record columns, URL path, etc.).
     /// </summary>
     public IReadOnlyList<string> FolderPath { get; init; } = [];
+
+    /// <summary>
+    /// Parse-fidelity report attached when the host produces this snapshot.
+    /// Repository-loaded clips that have never been parsed default to
+    /// <see cref="ClipParseReport.Empty"/>; the host populates the real report
+    /// when bridging from a live <see cref="Clip"/> aggregate.
+    /// </summary>
+    public ClipParseReport ParseReport { get; init; } = ClipParseReport.Empty;
 }

--- a/src/SharpFM.Model/Parsing/ClipParseReport.cs
+++ b/src/SharpFM.Model/Parsing/ClipParseReport.cs
@@ -4,14 +4,27 @@ namespace SharpFM.Model.Parsing;
 
 /// <summary>
 /// Aggregate of every <see cref="ClipParseDiagnostic"/> produced by parsing one
-/// clip. Lossless when empty; consumers check <see cref="IsLossless"/> rather
-/// than inspecting the collection directly.
+/// clip. Structural <see cref="Diagnostics"/> describe round-trip fidelity loss
+/// detected by <see cref="XmlRoundTripDiff"/>; <see cref="SemanticDiagnostics"/>
+/// describe domain-rule violations emitted by validators registered in
+/// <see cref="Validation.SemanticValidatorRegistry"/>. The two axes are kept
+/// distinct so consumers (status bar, tree glyph, plugins) can render structural
+/// fidelity and semantic correctness independently.
 /// </summary>
 public sealed record ClipParseReport(IReadOnlyList<ClipParseDiagnostic> Diagnostics)
 {
     /// <summary>Shared empty report used by clean parses to avoid allocating.</summary>
     public static ClipParseReport Empty { get; } = new([]);
 
-    /// <summary>True if the parse produced no diagnostics of any kind.</summary>
+    /// <summary>
+    /// Domain-rule violations from semantic validators. Defaults to empty so
+    /// the existing positional constructor stays source-compatible.
+    /// </summary>
+    public IReadOnlyList<ClipParseDiagnostic> SemanticDiagnostics { get; init; } = [];
+
+    /// <summary>True if the parse produced no structural diagnostics.</summary>
     public bool IsLossless => Diagnostics.Count == 0;
+
+    /// <summary>True if no semantic validators flagged the parsed model.</summary>
+    public bool IsSemanticallyValid => SemanticDiagnostics.Count == 0;
 }

--- a/src/SharpFM.Model/Validation/IClipSemanticValidator.cs
+++ b/src/SharpFM.Model/Validation/IClipSemanticValidator.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using SharpFM.Model.Parsing;
+
+namespace SharpFM.Model.Validation;
+
+/// <summary>
+/// Inspects a parsed <see cref="ClipModel"/> and emits diagnostics for
+/// domain-rule violations that <see cref="XmlRoundTripDiff"/> cannot detect —
+/// e.g. FileMaker variable-name conventions or calculation-syntax errors.
+/// Validators are pure, must not throw, and run on every successful parse.
+/// </summary>
+public interface IClipSemanticValidator
+{
+    /// <summary>
+    /// Sentinel <see cref="FormatIds"/> entry that opts the validator into
+    /// every clip type.
+    /// </summary>
+    public const string AllFormats = "*";
+
+    /// <summary>
+    /// Format ids this validator applies to (e.g. <c>"Mac-XMSS"</c>). Use
+    /// <see cref="AllFormats"/> to opt into every clip type.
+    /// </summary>
+    IReadOnlyCollection<string> FormatIds { get; }
+
+    /// <summary>Return any domain-rule violations found in <paramref name="model"/>.</summary>
+    IReadOnlyList<ClipParseDiagnostic> Validate(ClipModel model);
+}

--- a/src/SharpFM.Model/Validation/SemanticValidatorRegistry.cs
+++ b/src/SharpFM.Model/Validation/SemanticValidatorRegistry.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using SharpFM.Model.Parsing;
+
+namespace SharpFM.Model.Validation;
+
+/// <summary>
+/// Static registry of <see cref="IClipSemanticValidator"/>s the host runs after
+/// every successful clip parse. <see cref="BuiltIns"/> is the production set;
+/// the registry deliberately ships empty so domain rules can land one at a time
+/// without bundling the framework PR.
+/// </summary>
+public static class SemanticValidatorRegistry
+{
+    [ThreadStatic]
+    private static IReadOnlyList<IClipSemanticValidator>? _overrideForTest;
+
+    /// <summary>Validators that run on every parse in production.</summary>
+    public static IReadOnlyList<IClipSemanticValidator> BuiltIns { get; } = [];
+
+    /// <summary>
+    /// Run the built-in validators for <paramref name="formatId"/> against
+    /// <paramref name="model"/> and return the combined diagnostics. Returns
+    /// a shared empty list when nothing matches.
+    /// </summary>
+    public static IReadOnlyList<ClipParseDiagnostic> Run(string formatId, ClipModel model) =>
+        Run(formatId, model, _overrideForTest ?? BuiltIns);
+
+    /// <summary>
+    /// Per-thread override of <see cref="BuiltIns"/> for integration tests
+    /// that need to assert validators actually run through the parse pipeline.
+    /// Dispose to restore. Production code never sets this.
+    /// </summary>
+    internal static IDisposable OverrideForTest(IReadOnlyList<IClipSemanticValidator> validators)
+    {
+        _overrideForTest = validators;
+        return new Resetter();
+    }
+
+    private sealed class Resetter : IDisposable
+    {
+        public void Dispose() => _overrideForTest = null;
+    }
+
+    /// <summary>
+    /// Same as <see cref="Run(string, ClipModel)"/> but with an explicit
+    /// validator set — exposed for tests so the public <see cref="BuiltIns"/>
+    /// stays static and immutable.
+    /// </summary>
+    internal static IReadOnlyList<ClipParseDiagnostic> Run(
+        string formatId,
+        ClipModel model,
+        IReadOnlyList<IClipSemanticValidator> validators)
+    {
+        if (validators.Count == 0)
+        {
+            return Array.Empty<ClipParseDiagnostic>();
+        }
+
+        List<ClipParseDiagnostic>? acc = null;
+        foreach (var v in validators)
+        {
+            if (!Applies(v, formatId))
+            {
+                continue;
+            }
+
+            var diags = v.Validate(model);
+            if (diags.Count == 0)
+            {
+                continue;
+            }
+
+            (acc ??= []).AddRange(diags);
+        }
+        return (IReadOnlyList<ClipParseDiagnostic>?)acc ?? Array.Empty<ClipParseDiagnostic>();
+    }
+
+    private static bool Applies(IClipSemanticValidator validator, string formatId)
+    {
+        foreach (var id in validator.FormatIds)
+        {
+            if (id == IClipSemanticValidator.AllFormats || id == formatId)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/SharpFM.Plugin/IPluginHost.cs
+++ b/src/SharpFM.Plugin/IPluginHost.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SharpFM.Model;
+using SharpFM.Model.Parsing;
 using SharpFM.Model.Schema;
 using SharpFM.Model.Scripting;
 
@@ -62,6 +63,15 @@ public interface IPluginHost
     /// If the clip is currently selected, syncs the editor state first.
     /// </summary>
     ClipData? GetClip(string clipName);
+
+    /// <summary>
+    /// Parse <paramref name="xml"/> with the strategy registered for
+    /// <paramref name="clipType"/> and return the resulting fidelity report.
+    /// Pure — does not load or mutate any clip in the host. Lets plugins
+    /// pre-flight XML before pushing it through
+    /// <see cref="UpdateClipXml"/> or <see cref="UpdateSelectedClipXml"/>.
+    /// </summary>
+    ClipParseReport ValidateClipXml(string clipType, string xml);
 
     /// <summary>
     /// Replace the XML content of any loaded clip by name.

--- a/src/SharpFM/App.axaml.cs
+++ b/src/SharpFM/App.axaml.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using SharpFM.Dialogs;
 using SharpFM.Model.Scripting.Registry;
 using SharpFM.Models;
 using SharpFM.Plugin;
@@ -41,13 +42,15 @@ public partial class App : Application
             services.AddSingleton<IClipboardService>(x => new ClipboardService(desktop.MainWindow));
             Services = services.BuildServiceProvider();
 
+            var inputPrompt = new WindowInputPrompt(desktop.MainWindow);
             var viewModel = new MainWindowViewModel(
                 logger,
                 Services.GetRequiredService<IClipboardService>(),
-                Services.GetRequiredService<IFolderService>());
+                Services.GetRequiredService<IFolderService>(),
+                inputPrompt);
 
             // Load plugins
-            var pluginHost = new PluginHost(viewModel, loggerFactory);
+            var pluginHost = new PluginHost(viewModel, loggerFactory, inputPrompt);
             var pluginUIHost = new PluginUIHost(pluginHost);
             var pluginConfigService = new PluginConfigService(logger);
             var pluginService = new PluginService(logger, pluginConfigService);

--- a/src/SharpFM/Dialogs/IInputPrompt.cs
+++ b/src/SharpFM/Dialogs/IInputPrompt.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace SharpFM.Dialogs;
+
+/// <summary>
+/// Host-supplied input prompt used by view-models (and the plugin host) to
+/// ask the user for a single line of text. Abstracted so view-model tests
+/// can substitute a fake without standing up an Avalonia window.
+/// </summary>
+public interface IInputPrompt
+{
+    /// <summary>
+    /// Show a modal prompt and return the user's input, or <c>null</c> if
+    /// they cancelled.
+    /// </summary>
+    Task<string?> PromptAsync(string title, string prompt, string defaultValue);
+}

--- a/src/SharpFM/Dialogs/InputDialog.axaml
+++ b/src/SharpFM/Dialogs/InputDialog.axaml
@@ -1,0 +1,43 @@
+﻿<Window
+    x:Class="SharpFM.Dialogs.InputDialog"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Input"
+    Width="420"
+    SizeToContent="Height"
+    WindowStartupLocation="CenterOwner">
+
+    <Grid Margin="16" RowDefinitions="Auto,Auto,Auto">
+
+        <TextBlock
+            x:Name="promptLabel"
+            Grid.Row="0"
+            Margin="0,0,0,8"
+            Classes="Fluent2Body"
+            Text=""
+            TextWrapping="Wrap" />
+
+        <TextBox
+            x:Name="inputBox"
+            Grid.Row="1"
+            Margin="0,0,0,12" />
+
+        <StackPanel
+            Grid.Row="2"
+            HorizontalAlignment="Right"
+            Orientation="Horizontal"
+            Spacing="8">
+            <Button
+                x:Name="cancelButton"
+                Classes="Fluent2"
+                Content="Cancel" />
+            <Button
+                x:Name="okButton"
+                Classes="Fluent2Primary"
+                Content="OK"
+                IsDefault="True" />
+        </StackPanel>
+
+    </Grid>
+
+</Window>

--- a/src/SharpFM/Dialogs/InputDialog.axaml.cs
+++ b/src/SharpFM/Dialogs/InputDialog.axaml.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace SharpFM.Dialogs;
+
+/// <summary>
+/// Single-line text-input modal. The host application's production
+/// <see cref="IInputPrompt"/> opens this dialog over the main window; tests
+/// use a fake prompt and never construct this class.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public partial class InputDialog : Window
+{
+    private readonly TextBlock _promptLabel;
+    private readonly TextBox _inputBox;
+
+    public string? Result { get; private set; }
+
+    public InputDialog()
+    {
+        AvaloniaXamlLoader.Load(this);
+        _promptLabel = this.FindControl<TextBlock>("promptLabel")!;
+        _inputBox = this.FindControl<TextBox>("inputBox")!;
+
+        this.FindControl<Button>("okButton")!.Click += (_, _) =>
+        {
+            Result = _inputBox.Text ?? string.Empty;
+            Close();
+        };
+        this.FindControl<Button>("cancelButton")!.Click += (_, _) => Close();
+    }
+
+    public void Configure(string title, string prompt, string defaultValue)
+    {
+        Title = title;
+        _promptLabel.Text = prompt;
+        _inputBox.Text = defaultValue;
+        _inputBox.SelectAll();
+        _inputBox.Focus();
+    }
+
+    public static async Task<string?> PromptAsync(
+        Window owner,
+        string title,
+        string prompt,
+        string defaultValue)
+    {
+        var window = new InputDialog();
+        window.Configure(title, prompt, defaultValue);
+        await window.ShowDialog(owner);
+        return window.Result;
+    }
+}

--- a/src/SharpFM/Dialogs/NullInputPrompt.cs
+++ b/src/SharpFM/Dialogs/NullInputPrompt.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace SharpFM.Dialogs;
+
+/// <summary>
+/// Default <see cref="IInputPrompt"/> for environments without a UI thread
+/// (headless tests, the legacy view-model ctor path). Returns the supplied
+/// default verbatim, simulating a "user accepted the prefill" outcome
+/// without surfacing anything visible.
+/// </summary>
+public sealed class NullInputPrompt : IInputPrompt
+{
+    public Task<string?> PromptAsync(string title, string prompt, string defaultValue) =>
+        Task.FromResult<string?>(defaultValue);
+}

--- a/src/SharpFM/Dialogs/WindowInputPrompt.cs
+++ b/src/SharpFM/Dialogs/WindowInputPrompt.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+
+namespace SharpFM.Dialogs;
+
+/// <summary>
+/// Production <see cref="IInputPrompt"/>. Opens an <see cref="InputDialog"/>
+/// modal over the supplied owner window.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class WindowInputPrompt(Window owner) : IInputPrompt
+{
+    public Task<string?> PromptAsync(string title, string prompt, string defaultValue) =>
+        InputDialog.PromptAsync(owner, title, prompt, defaultValue);
+}

--- a/src/SharpFM/MainWindow.axaml
+++ b/src/SharpFM/MainWindow.axaml
@@ -177,6 +177,7 @@
                                 <TextBlock Classes="Fluent2Subtitle" Text="Available Clips" />
                                 <TreeView
                                     x:Name="clipsTreeView"
+                                    ContextRequested="ClipsTree_ContextRequested"
                                     DoubleTapped="ClipsTree_DoubleTapped"
                                     ItemsSource="{Binding RootNodes}"
                                     Tapped="ClipsTree_Tapped">

--- a/src/SharpFM/MainWindow.axaml
+++ b/src/SharpFM/MainWindow.axaml
@@ -4,44 +4,61 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:AvaloniaEdit="clr-namespace:AvaloniaEdit;assembly=AvaloniaEdit"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:vm="using:SharpFM.ViewModels"
     xmlns:editors="using:SharpFM.Editors"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:schema="using:SharpFM.Schema.Editor"
-    Icon="/Assets/noun-sharp-teeth-monster-4226695.small.png"
+    xmlns:vm="using:SharpFM.ViewModels"
     Title="SharpFM"
     Width="700"
     Height="500"
     d:DesignHeight="500"
     d:DesignWidth="700"
     x:DataType="vm:MainWindowViewModel"
+    Icon="/Assets/noun-sharp-teeth-monster-4226695.small.png"
     mc:Ignorable="d">
 
     <Window.KeyBindings>
-        <KeyBinding Gesture="Ctrl+S" Command="{Binding SaveClipsStorage}" />
-        <KeyBinding Gesture="Ctrl+N" Command="{Binding NewScriptCommand}" />
-        <KeyBinding Gesture="Ctrl+Shift+N" Command="{Binding NewTableCommand}" />
-        <KeyBinding Gesture="Ctrl+Shift+C" Command="{Binding CopySelectedToClip}" />
-        <!-- Ctrl+V is wired in code-behind via a tunnel-phase preview
-             handler so it can defer to the focused text editor (TextBox /
-             AvaloniaEdit) and only fall through to the FileMaker-clip
-             paste when focus is on the tree, tabs, or window background. -->
+        <KeyBinding Command="{Binding SaveClipsStorage}" Gesture="Ctrl+S" />
+        <KeyBinding Command="{Binding NewScriptCommand}" Gesture="Ctrl+N" />
+        <KeyBinding Command="{Binding NewTableCommand}" Gesture="Ctrl+Shift+N" />
+        <KeyBinding Command="{Binding CopySelectedToClip}" Gesture="Ctrl+Shift+C" />
+        <!--
+            Ctrl+V is wired in code-behind via a tunnel-phase preview
+            handler so it can defer to the focused text editor (TextBox /
+            AvaloniaEdit) and only fall through to the FileMaker-clip
+            paste when focus is on the tree, tabs, or window background.
+        -->
     </Window.KeyBindings>
 
     <DockPanel>
         <Menu DockPanel.Dock="Top">
             <MenuItem Header="_File">
-                <MenuItem Command="{Binding NewScriptCommand}" Header="New Script" InputGesture="Ctrl+N" />
-                <MenuItem Command="{Binding NewTableCommand}" Header="New Table" InputGesture="Ctrl+Shift+N" />
+                <MenuItem
+                    Command="{Binding NewScriptCommand}"
+                    Header="New Script"
+                    InputGesture="Ctrl+N" />
+                <MenuItem
+                    Command="{Binding NewTableCommand}"
+                    Header="New Table"
+                    InputGesture="Ctrl+Shift+N" />
                 <Separator />
                 <MenuItem Command="{Binding OpenFolderPicker}" Header="Open Folder..." />
-                <MenuItem Command="{Binding SaveClipsStorage}" Header="Save All" InputGesture="Ctrl+S" />
+                <MenuItem
+                    Command="{Binding SaveClipsStorage}"
+                    Header="Save All"
+                    InputGesture="Ctrl+S" />
                 <Separator />
                 <MenuItem Command="{Binding ExitApplication}" Header="_Exit" />
             </MenuItem>
             <MenuItem Header="_Edit">
-                <MenuItem Command="{Binding PasteFileMakerClipData}" Header="Paste from FileMaker" InputGesture="Ctrl+V" />
-                <MenuItem Command="{Binding CopySelectedToClip}" Header="Copy to FileMaker" InputGesture="Ctrl+Shift+C" />
+                <MenuItem
+                    Command="{Binding PasteFileMakerClipData}"
+                    Header="Paste from FileMaker"
+                    InputGesture="Ctrl+V" />
+                <MenuItem
+                    Command="{Binding CopySelectedToClip}"
+                    Header="Copy to FileMaker"
+                    InputGesture="Ctrl+Shift+C" />
                 <MenuItem Command="{Binding CopyAsScript}" Header="Copy as Script (whole script)" />
                 <MenuItem Command="{Binding CopyAsScriptSteps}" Header="Copy as Script Steps (lines only)" />
                 <Separator />
@@ -53,40 +70,40 @@
                 <MenuItem x:Name="rawClipboardMenuItem" Header="Raw Clipboard Viewer..." />
             </MenuItem>
             <MenuItem x:Name="pluginsMenu" Header="_Plugins">
-                <!-- Plugin menu items are added dynamically in code-behind -->
+                <!--  Plugin menu items are added dynamically in code-behind  -->
                 <MenuItem x:Name="managePluginsMenuItem" Header="Manage Plugins..." />
             </MenuItem>
         </Menu>
 
-        <!-- Status bar -->
+        <!--  Status bar  -->
         <Border
-            DockPanel.Dock="Bottom"
+            Padding="16,6"
             Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-            Padding="16,6">
+            DockPanel.Dock="Bottom">
             <Grid>
                 <TextBlock
-                    Classes="Fluent2Caption"
                     HorizontalAlignment="Left"
+                    Classes="Fluent2Caption"
                     IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                     Text="{Binding StatusMessage}" />
                 <StackPanel
                     HorizontalAlignment="Center"
+                    IsVisible="{Binding ParseFidelityVisible}"
                     Orientation="Horizontal"
-                    Spacing="6"
-                    IsVisible="{Binding ParseFidelityVisible}">
+                    Spacing="6">
                     <TextBlock
                         Classes="Fluent2Caption"
                         Foreground="DarkOrange"
-                        Text="!"
-                        IsVisible="{Binding !ParseFidelityIsLossless}" />
+                        IsVisible="{Binding !ParseFidelityIsLossless}"
+                        Text="!" />
                     <TextBlock
                         Classes="Fluent2Caption"
                         Opacity="0.7"
                         Text="{Binding ParseFidelitySummary}" />
                 </StackPanel>
                 <TextBlock
-                    Classes="Fluent2Caption"
                     HorizontalAlignment="Right"
+                    Classes="Fluent2Caption"
                     Opacity="0.5"
                     Text="{Binding Version}" />
             </Grid>
@@ -98,95 +115,80 @@
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
-            <!-- Header section with Fluent 2 design tokens -->
-            <Border 
+            <!--  Header section with Fluent 2 design tokens  -->
+            <Border
                 Grid.Row="0"
-                Classes="Fluent2Surface"
                 Margin="24,16,24,0"
-                Padding="16">
+                Padding="16"
+                Classes="Fluent2Surface">
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
-                    <TextBlock 
-                        Grid.Column="0" 
+                    <TextBlock
+                        Grid.Column="0"
+                        Margin="0,0,12,0"
+                        VerticalAlignment="Center"
                         Classes="Fluent2Body"
-                        Margin="0,0,12,0"
-                        VerticalAlignment="Center" 
                         Text="Clip path:" />
-                    <TextBox 
-                        Grid.Column="1" 
-                        Classes="Fluent2"
+                    <TextBox
+                        Grid.Column="1"
                         Margin="0,0,12,0"
+                        Classes="Fluent2"
                         Text="{Binding CurrentPath, Mode=OneWay}" />
-                    <Button 
-                        Grid.Column="2" 
+                    <Button
+                        Grid.Column="2"
                         Classes="Fluent2Primary"
-                        Command="{Binding OpenFolderPicker}" 
+                        Command="{Binding OpenFolderPicker}"
                         Content="Browse" />
                 </Grid>
             </Border>
 
-            <!-- Main content area with Fluent 2 elevation and spacing -->
-            <Grid 
-                Grid.Row="1" 
-                Margin="24,16,24,24">
+            <!--  Main content area with Fluent 2 elevation and spacing  -->
+            <Grid Grid.Row="1" Margin="24,16,24,24">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="320" />
                     <ColumnDefinition Width="16" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <!-- Left panel: Clips navigation with Fluent 2 surface treatment -->
-                <Border 
-                    Grid.Column="0"
-                    Classes="Fluent2SurfaceElevated">
+                <!--  Left panel: Clips navigation with Fluent 2 surface treatment  -->
+                <Border Grid.Column="0" Classes="Fluent2SurfaceElevated">
                     <ScrollViewer>
                         <StackPanel Margin="16" Spacing="16">
-                            <!-- Search section -->
+                            <!--  Search section  -->
                             <StackPanel Spacing="8">
-                                <TextBlock 
-                                    Classes="Fluent2Subtitle"
-                                    Text="Search Clips" />
-                                <TextBox 
+                                <TextBlock Classes="Fluent2Subtitle" Text="Search Clips" />
+                                <TextBox
                                     Classes="Fluent2"
-                                    Watermark="Type to search clips..." 
-                                    Text="{Binding SearchText}" />
+                                    Text="{Binding SearchText}"
+                                    Watermark="Type to search clips..." />
                             </StackPanel>
 
-                            <!-- Clips tree section. Mirrors the repository's folder
-                                 hierarchy (ClipViewModel.FolderPath). Single-tap a
-                                 clip for a preview tab, double-tap for a permanent
-                                 tab. -->
+                            <!--
+                                Clips tree section. Mirrors the repository's folder
+                                hierarchy (ClipViewModel.FolderPath). Single-tap a
+                                clip for a preview tab, double-tap for a permanent
+                                tab.
+                            -->
                             <StackPanel Spacing="8">
-                                <TextBlock
-                                    Classes="Fluent2Subtitle"
-                                    Text="Available Clips" />
+                                <TextBlock Classes="Fluent2Subtitle" Text="Available Clips" />
                                 <TreeView
                                     x:Name="clipsTreeView"
+                                    DoubleTapped="ClipsTree_DoubleTapped"
                                     ItemsSource="{Binding RootNodes}"
-                                    Tapped="ClipsTree_Tapped"
-                                    DoubleTapped="ClipsTree_DoubleTapped">
+                                    Tapped="ClipsTree_Tapped">
                                     <TreeView.ContextMenu>
                                         <ContextMenu>
-                                            <MenuItem
-                                                Command="{Binding CopySelectedToClip}"
-                                                Header="Copy to FileMaker" />
-                                            <MenuItem
-                                                Command="{Binding CopyAsScript}"
-                                                Header="Copy as Script" />
-                                            <MenuItem
-                                                Command="{Binding CopyAsScriptSteps}"
-                                                Header="Copy as Script Steps" />
-                                            <MenuItem
-                                                Command="{Binding CopyAsClass}"
-                                                Header="Copy as C# Class" />
+                                            <MenuItem Command="{Binding CopySelectedToClip}" Header="Copy to FileMaker" />
+                                            <MenuItem Command="{Binding CopyAsScript}" Header="Copy as Script" />
+                                            <MenuItem Command="{Binding CopyAsScriptSteps}" Header="Copy as Script Steps" />
+                                            <MenuItem Command="{Binding CopyAsClass}" Header="Copy as C# Class" />
                                             <Separator />
-                                            <MenuItem
-                                                Command="{Binding DeleteSelectedClip}"
-                                                Header="Delete Clip" />
+                                            <MenuItem Command="{Binding RenameSelectedClip}" Header="Rename..." />
+                                            <MenuItem Command="{Binding DeleteSelectedClip}" Header="Delete Clip" />
                                         </ContextMenu>
                                     </TreeView.ContextMenu>
                                     <TreeView.DataTemplates>
@@ -197,9 +199,9 @@
                                                     IsVisible="{Binding IsFolder}"
                                                     Text="{Binding Name}" />
                                                 <StackPanel
+                                                    IsVisible="{Binding IsClip}"
                                                     Orientation="Horizontal"
-                                                    Spacing="6"
-                                                    IsVisible="{Binding IsClip}">
+                                                    Spacing="6">
                                                     <TextBlock Text="{Binding Clip.Clip.Name}" />
                                                     <TextBlock
                                                         Classes="Fluent2Caption"
@@ -221,14 +223,14 @@
                     </ScrollViewer>
                 </Border>
 
-                <!-- Splitter space -->
-                <GridSplitter 
-                    Grid.Column="1" 
+                <!--  Splitter space  -->
+                <GridSplitter
+                    Grid.Column="1"
+                    Width="16"
                     Background="Transparent"
-                    ResizeDirection="Columns"
-                    Width="16" />
+                    ResizeDirection="Columns" />
 
-                <!-- Right panel: Editor + optional plugin sidebar -->
+                <!--  Right panel: Editor + optional plugin sidebar  -->
                 <Grid x:Name="editorPluginGrid" Grid.Column="2">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -236,29 +238,31 @@
                         <ColumnDefinition Width="0" />
                     </Grid.ColumnDefinitions>
 
-                    <!-- Open clips area: VS Code-style tab strip. Each tab wraps
-                         a ClipViewModel; the tab header italicizes for preview
-                         tabs and shows a dirty dot when the clip has unsaved
-                         edits. The tab body reuses the existing per-editor
-                         DataTemplates. -->
-                    <Border
-                        Grid.Column="0"
-                        Classes="Fluent2SurfaceElevated">
+                    <!--
+                        Open clips area: VS Code-style tab strip. Each tab wraps
+                        a ClipViewModel; the tab header italicizes for preview
+                        tabs and shows a dirty dot when the clip has unsaved
+                        edits. The tab body reuses the existing per-editor
+                        DataTemplates.
+                    -->
+                    <Border Grid.Column="0" Classes="Fluent2SurfaceElevated">
                         <Grid>
                             <TextBlock
-                                Classes="Fluent2Caption"
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center"
-                                Opacity="0.6"
+                                Classes="Fluent2Caption"
                                 IsVisible="{Binding !OpenTabs.Tabs.Count}"
+                                Opacity="0.6"
                                 Text="Single-tap a clip to preview, double-tap to open." />
 
-                            <!-- TabStrip for headers; a separate ItemsControl
-                                 realises every open editor into the visual tree
-                                 once and toggles IsVisible per tab. This avoids
-                                 reparenting AvaloniaEdit on each switch, which
-                                 triggers costly layout/tokenise passes. -->
-                                <DockPanel IsVisible="{Binding OpenTabs.Tabs.Count}">
+                            <!--
+                                TabStrip for headers; a separate ItemsControl
+                                realises every open editor into the visual tree
+                                once and toggles IsVisible per tab. This avoids
+                                reparenting AvaloniaEdit on each switch, which
+                                triggers costly layout/tokenise passes.
+                            -->
+                            <DockPanel IsVisible="{Binding OpenTabs.Tabs.Count}">
                                 <TabStrip
                                     x:Name="openTabStrip"
                                     DockPanel.Dock="Top"
@@ -290,34 +294,37 @@
                                     </TabStrip.Styles>
                                     <TabStrip.ItemTemplate>
                                         <DataTemplate DataType="vm:OpenTabViewModel">
-                                            <StackPanel Orientation="Horizontal" Spacing="8" DoubleTapped="TabHeader_DoubleTapped">
+                                            <StackPanel
+                                                DoubleTapped="TabHeader_DoubleTapped"
+                                                Orientation="Horizontal"
+                                                Spacing="8">
                                                 <TextBlock
+                                                    MaxWidth="200"
                                                     VerticalAlignment="Center"
                                                     FontSize="14"
-                                                    MaxWidth="200"
-                                                    TextTrimming="CharacterEllipsis"
-                                                    ToolTip.Tip="{Binding Title}"
                                                     FontStyle="{Binding TitleFontStyle}"
-                                                    Text="{Binding Title}" />
+                                                    Text="{Binding Title}"
+                                                    TextTrimming="CharacterEllipsis"
+                                                    ToolTip.Tip="{Binding Title}" />
                                                 <Ellipse
-                                                    Width="6" Height="6"
+                                                    Width="6"
+                                                    Height="6"
                                                     VerticalAlignment="Center"
                                                     Fill="{DynamicResource SystemAccentColorBrush}"
                                                     IsVisible="{Binding IsDirty}" />
                                                 <Button
                                                     Padding="4,0"
-                                                    FontSize="12"
                                                     Background="Transparent"
                                                     BorderThickness="0"
-                                                    Content="✕"
                                                     Click="CloseTab_Click"
+                                                    Content="✕"
+                                                    FontSize="12"
                                                     Tag="{Binding}" />
                                             </StackPanel>
                                         </DataTemplate>
                                     </TabStrip.ItemTemplate>
                                 </TabStrip>
-                                <ItemsControl
-                                    ItemsSource="{Binding OpenTabs.Tabs}">
+                                <ItemsControl ItemsSource="{Binding OpenTabs.Tabs}">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
                                             <Grid />
@@ -325,9 +332,7 @@
                                     </ItemsControl.ItemsPanel>
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate DataType="vm:OpenTabViewModel">
-                                            <ContentControl
-                                                Content="{Binding Clip.EditorView}"
-                                                IsVisible="{Binding IsActive}" />
+                                            <ContentControl Content="{Binding Clip.EditorView}" IsVisible="{Binding IsActive}" />
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
@@ -335,16 +340,16 @@
                         </Grid>
                     </Border>
 
-                    <!-- Plugin panel splitter -->
+                    <!--  Plugin panel splitter  -->
                     <GridSplitter
                         x:Name="pluginSplitter"
                         Grid.Column="1"
+                        Width="16"
                         Background="Transparent"
-                        ResizeDirection="Columns"
                         IsVisible="False"
-                        Width="16" />
+                        ResizeDirection="Columns" />
 
-                    <!-- Plugin panel host -->
+                    <!--  Plugin panel host  -->
                     <Border
                         x:Name="pluginPanelBorder"
                         Grid.Column="2"

--- a/src/SharpFM/MainWindow.axaml.cs
+++ b/src/SharpFM/MainWindow.axaml.cs
@@ -229,6 +229,17 @@ public partial class MainWindow : Window
         vm.OpenClipAsPreview(node.Clip);
     }
 
+    // Right-click bypasses the Tapped handler, so the context menu would
+    // otherwise operate on whatever was previously selected. Promote the
+    // right-clicked node into the active selection before the menu opens.
+    private void ClipsTree_ContextRequested(object? sender, ContextRequestedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        var node = FindClipNode(e.Source);
+        if (node?.Clip is null) return;
+        vm.OpenClipAsPreview(node.Clip);
+    }
+
     private void ClipsTree_DoubleTapped(object? sender, TappedEventArgs e)
     {
         if (DataContext is not MainWindowViewModel vm) return;

--- a/src/SharpFM/Services/PluginHost.cs
+++ b/src/SharpFM/Services/PluginHost.cs
@@ -60,7 +60,7 @@ public class PluginHost : IPluginHost
         {
             var clip = _viewModel.SelectedClip;
             if (clip is null) return null;
-            return new ClipData(clip.Clip.Name, clip.ClipType, clip.Clip.Xml);
+            return ToClipData(clip);
         }
     }
 
@@ -69,9 +69,10 @@ public class PluginHost : IPluginHost
     public event EventHandler? ClipCollectionChanged;
 
     public IReadOnlyList<ClipData> AllClips =>
-        _viewModel.FileMakerClips
-            .Select(c => new ClipData(c.Clip.Name, c.ClipType, c.Clip.Xml))
-            .ToList();
+        _viewModel.FileMakerClips.Select(ToClipData).ToList();
+
+    private static ClipData ToClipData(ClipViewModel clip) =>
+        new(clip.Clip.Name, clip.ClipType, clip.Clip.Xml) { ParseReport = clip.ParseReport };
 
     public ILogger CreateLogger(string categoryName) => _loggerFactory.CreateLogger(categoryName);
 
@@ -86,15 +87,16 @@ public class PluginHost : IPluginHost
 
             clip.Replace(xml);
 
-            var info = new ClipData(clip.Clip.Name, clip.ClipType, clip.Clip.Xml);
-            ClipContentChanged?.Invoke(this, new ClipContentChangedArgs(info, originPluginId, false));
+            ClipContentChanged?.Invoke(
+                this,
+                new ClipContentChangedArgs(ToClipData(clip), originPluginId, false));
         });
 
     public ClipData? GetClip(string clipName)
     {
         var clip = FindClipByName(clipName);
         if (clip is null) return null;
-        return new ClipData(clip.Clip.Name, clip.ClipType, clip.Clip.Xml);
+        return ToClipData(clip);
     }
 
     public void UpdateClipXml(string clipName, string xml, string originPluginId) =>
@@ -105,8 +107,9 @@ public class PluginHost : IPluginHost
 
             clip.Replace(xml);
 
-            var info = new ClipData(clip.Clip.Name, clip.ClipType, clip.Clip.Xml);
-            ClipContentChanged?.Invoke(this, new ClipContentChangedArgs(info, originPluginId, false));
+            ClipContentChanged?.Invoke(
+                this,
+                new ClipContentChangedArgs(ToClipData(clip), originPluginId, false));
         });
 
     public void CreateClip(string name, string clipType, string? xml = null)
@@ -189,8 +192,8 @@ public class PluginHost : IPluginHost
         var clip = _viewModel.SelectedClip;
         if (clip is null) return;
 
-        var info = new ClipData(clip.Clip.Name, clip.ClipType, clip.Clip.Xml);
-        var isPartial = clip.Editor.IsPartial;
-        ClipContentChanged?.Invoke(this, new ClipContentChangedArgs(info, "editor", isPartial));
+        ClipContentChanged?.Invoke(
+            this,
+            new ClipContentChangedArgs(ToClipData(clip), "editor", clip.Editor.IsPartial));
     }
 }

--- a/src/SharpFM/Services/PluginHost.cs
+++ b/src/SharpFM/Services/PluginHost.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using Microsoft.Extensions.Logging;
+using SharpFM.Dialogs;
 using SharpFM.Model;
 using SharpFM.Model.ClipTypes;
 using SharpFM.Model.Parsing;
@@ -23,6 +24,7 @@ public class PluginHost : IPluginHost
 {
     private readonly MainWindowViewModel _viewModel;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly IInputPrompt _prompt;
     private ClipViewModel? _trackedClip;
     private readonly List<IClipRepository> _repositories = [];
     private readonly List<IClipTransform> _transforms = [];
@@ -33,10 +35,11 @@ public class PluginHost : IPluginHost
     /// <summary>Transforms registered by plugins.</summary>
     public IReadOnlyList<IClipTransform> Transforms => _transforms;
 
-    public PluginHost(MainWindowViewModel viewModel, ILoggerFactory loggerFactory)
+    public PluginHost(MainWindowViewModel viewModel, ILoggerFactory loggerFactory, IInputPrompt? prompt = null)
     {
         _viewModel = viewModel;
         _loggerFactory = loggerFactory;
+        _prompt = prompt ?? new NullInputPrompt();
         _viewModel.PropertyChanged += (_, e) =>
         {
             if (e.PropertyName != nameof(MainWindowViewModel.SelectedClip)) return;
@@ -153,12 +156,8 @@ public class PluginHost : IPluginHost
         return Task.FromResult<string?>(null);
     }
 
-    public Task<string?> ShowInputDialogAsync(string title, string prompt, string? defaultValue = null)
-    {
-        // TODO: implement with Avalonia dialog
-        ShowStatus(prompt);
-        return Task.FromResult(defaultValue);
-    }
+    public Task<string?> ShowInputDialogAsync(string title, string prompt, string? defaultValue = null) =>
+        _prompt.PromptAsync(title, prompt, defaultValue ?? string.Empty);
 
     private ClipViewModel? FindClipByName(string clipName) =>
         _viewModel.FileMakerClips.FirstOrDefault(c =>

--- a/src/SharpFM/Services/PluginHost.cs
+++ b/src/SharpFM/Services/PluginHost.cs
@@ -6,6 +6,7 @@ using Avalonia.Threading;
 using Microsoft.Extensions.Logging;
 using SharpFM.Model;
 using SharpFM.Model.ClipTypes;
+using SharpFM.Model.Parsing;
 using SharpFM.Model.Schema;
 using SharpFM.Model.Scripting;
 using SharpFM.Plugin;
@@ -98,6 +99,9 @@ public class PluginHost : IPluginHost
         if (clip is null) return null;
         return ToClipData(clip);
     }
+
+    public ClipParseReport ValidateClipXml(string clipType, string xml) =>
+        ClipTypeRegistry.For(clipType).Parse(xml).Report;
 
     public void UpdateClipXml(string clipName, string xml, string originPluginId) =>
         EnsureUiThread(() =>

--- a/src/SharpFM/Services/PluginUIHost.cs
+++ b/src/SharpFM/Services/PluginUIHost.cs
@@ -88,6 +88,7 @@ public class PluginUIHost : IPluginUIHost, INotifyPropertyChanged
     }
     public void ShowStatus(string message) => _baseHost.ShowStatus(message);
     public Model.ClipData? GetClip(string clipName) => _baseHost.GetClip(clipName);
+    public Model.Parsing.ClipParseReport ValidateClipXml(string clipType, string xml) => _baseHost.ValidateClipXml(clipType, xml);
     public void UpdateClipXml(string clipName, string xml, string originPluginId) => _baseHost.UpdateClipXml(clipName, xml, originPluginId);
     public void CreateClip(string name, string clipType, string? xml = null) => _baseHost.CreateClip(name, clipType, xml);
     public bool RemoveClip(string clipName) => _baseHost.RemoveClip(clipName);

--- a/src/SharpFM/ViewModels/ClipViewModel.cs
+++ b/src/SharpFM/ViewModels/ClipViewModel.cs
@@ -80,6 +80,9 @@ public partial class ClipViewModel : INotifyPropertyChanged, IDisposable
         _editorView = null;
     }
 
+    /// <summary>Rename the underlying clip; the cached parse carries over.</summary>
+    public void RenameTo(string newName) => Clip = _clip.Rename(newName);
+
     /// <summary>Re-parse the clip with new XML; used for external updates (MCP, plugins, XML viewer).</summary>
     public void Replace(string xml)
     {

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -11,6 +11,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using Microsoft.Extensions.Logging;
+using SharpFM.Dialogs;
 using SharpFM.Models;
 using SharpFM.Model;
 using SharpFM.Model.ClipTypes;
@@ -26,6 +27,7 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
     private readonly ILogger _logger;
     private readonly IClipboardService _clipboard;
     private readonly IFolderService _folderService;
+    private readonly IInputPrompt _prompt;
     private readonly DispatcherTimer _statusTimer;
     private IClipRepository _repository;
     private OpenTabViewModel? _trackedActiveTab;
@@ -80,11 +82,13 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
     public MainWindowViewModel(
         ILogger logger,
         IClipboardService clipboard,
-        IFolderService folderService)
+        IFolderService folderService,
+        IInputPrompt? prompt = null)
     {
         _logger = logger;
         _clipboard = clipboard;
         _folderService = folderService;
+        _prompt = prompt ?? new NullInputPrompt();
 
         _statusTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
         _statusTimer.Tick += (_, _) =>
@@ -244,6 +248,29 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+
+    public async Task RenameSelectedClip()
+    {
+        var clip = SelectedClip;
+        if (clip is null)
+        {
+            ShowStatus("No clip selected");
+            return;
+        }
+
+        var current = clip.Clip.Name;
+        var entered = await _prompt.PromptAsync("Rename clip", "New name:", current);
+        if (entered is null) return;
+
+        var trimmed = entered.Trim();
+        if (trimmed.Length == 0 || trimmed == current) return;
+
+        clip.RenameTo(trimmed);
+        // Tree label binds Clip.Clip.Name; the rebuild also re-sorts under the
+        // new name so the node lands in the right folder slot.
+        RebuildTree();
+        ShowStatus($"Renamed to '{trimmed}'");
+    }
 
     public void DeleteSelectedClip()
     {

--- a/tests/SharpFM.Plugin.Tests/PluginHostTests.cs
+++ b/tests/SharpFM.Plugin.Tests/PluginHostTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using SharpFM.Model;
+using SharpFM.Model.Parsing;
 using SharpFM.Plugin;
 using SharpFM.Services;
 using SharpFM.ViewModels;
@@ -184,5 +185,77 @@ public class PluginHostTests
         host.ShowStatus("Plugin says hello");
 
         Assert.Equal("Plugin says hello", vm.StatusMessage);
+    }
+
+    // --- Item 1: ClipData.ParseReport ---
+
+    [Fact]
+    public void SelectedClip_ExposesParseReport_FromClip()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm, NullLoggerFactory.Instance);
+
+        vm.NewScriptCommand();
+
+        Assert.NotNull(host.SelectedClip);
+        Assert.NotNull(host.SelectedClip!.ParseReport);
+        Assert.True(host.SelectedClip.ParseReport.IsLossless);
+    }
+
+    [Fact]
+    public void SelectedClip_ParseReport_SurfacesDiagnostics()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm, NullLoggerFactory.Instance);
+        vm.NewScriptCommand();
+
+        host.UpdateSelectedClipXml(
+            "<fmxmlsnippet type=\"FMObjectList\"><Mystery /></fmxmlsnippet>",
+            "test-plugin");
+
+        var report = host.SelectedClip!.ParseReport;
+        Assert.False(report.IsLossless);
+        Assert.NotEmpty(report.Diagnostics);
+    }
+
+    [Fact]
+    public void AllClips_PopulatesParseReport()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm, NullLoggerFactory.Instance);
+        vm.NewScriptCommand();
+        vm.NewTableCommand();
+
+        Assert.All(host.AllClips, c => Assert.NotNull(c.ParseReport));
+    }
+
+    [Fact]
+    public void GetClip_PopulatesParseReport()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm, NullLoggerFactory.Instance);
+        vm.NewScriptCommand();
+
+        var clip = host.GetClip("New Script");
+
+        Assert.NotNull(clip);
+        Assert.NotNull(clip!.ParseReport);
+    }
+
+    [Fact]
+    public void ClipContentChanged_FromUpdate_CarriesParseReport()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm, NullLoggerFactory.Instance);
+        vm.NewScriptCommand();
+        ClipContentChangedArgs? args = null;
+        host.ClipContentChanged += (_, e) => args = e;
+
+        host.UpdateSelectedClipXml(
+            "<fmxmlsnippet type=\"FMObjectList\"></fmxmlsnippet>",
+            "test-plugin");
+
+        Assert.NotNull(args);
+        Assert.NotNull(args!.Clip.ParseReport);
     }
 }

--- a/tests/SharpFM.Plugin.Tests/PluginHostTests.cs
+++ b/tests/SharpFM.Plugin.Tests/PluginHostTests.cs
@@ -258,4 +258,56 @@ public class PluginHostTests
         Assert.NotNull(args);
         Assert.NotNull(args!.Clip.ParseReport);
     }
+
+    // --- Item 2: ValidateClipXml ---
+
+    [Fact]
+    public void ValidateClipXml_Lossless_OnCleanScriptStepsXml()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm, NullLoggerFactory.Instance);
+
+        var report = host.ValidateClipXml(
+            "Mac-XMSS",
+            "<fmxmlsnippet type=\"FMObjectList\"></fmxmlsnippet>");
+
+        Assert.True(report.IsLossless);
+    }
+
+    [Fact]
+    public void ValidateClipXml_ReportsXmlMalformed_OnGarbage()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm, NullLoggerFactory.Instance);
+
+        var report = host.ValidateClipXml("Mac-XMSS", "<oops>");
+
+        Assert.False(report.IsLossless);
+        Assert.Contains(
+            report.Diagnostics,
+            d => d.Kind == ParseDiagnosticKind.XmlMalformed);
+    }
+
+    [Fact]
+    public void ValidateClipXml_FallsBackToOpaque_OnUnknownType()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm, NullLoggerFactory.Instance);
+
+        var report = host.ValidateClipXml("Mac-XMUNKNOWN", "<root/>");
+
+        Assert.True(report.IsLossless);
+    }
+
+    [Fact]
+    public void ValidateClipXml_DoesNotMutateClipCollection()
+    {
+        var vm = CreateVm();
+        var host = new PluginHost(vm, NullLoggerFactory.Instance);
+        var beforeCount = host.AllClips.Count;
+
+        host.ValidateClipXml("Mac-XMSS", "<fmxmlsnippet type=\"FMObjectList\"></fmxmlsnippet>");
+
+        Assert.Equal(beforeCount, host.AllClips.Count);
+    }
 }

--- a/tests/SharpFM.Plugin.Tests/PluginServiceTests.cs
+++ b/tests/SharpFM.Plugin.Tests/PluginServiceTests.cs
@@ -18,6 +18,7 @@ public class MockPluginHost : IPluginHost
     public event EventHandler? ClipCollectionChanged;
     public ILogger CreateLogger(string categoryName) => NullLogger.Instance;
     public ClipData? GetClip(string clipName) => AllClips.FirstOrDefault(c => c.Name.Equals(clipName, StringComparison.OrdinalIgnoreCase));
+    public SharpFM.Model.Parsing.ClipParseReport ValidateClipXml(string clipType, string xml) => SharpFM.Model.Parsing.ClipParseReport.Empty;
     public void UpdateClipXml(string clipName, string xml, string originPluginId) { }
     public void CreateClip(string name, string clipType, string? xml = null) { }
     public bool RemoveClip(string clipName) => false;

--- a/tests/SharpFM.Plugin.Tests/XmlViewerPluginTests.cs
+++ b/tests/SharpFM.Plugin.Tests/XmlViewerPluginTests.cs
@@ -152,6 +152,7 @@ public class TrackingPluginHost : IPluginHost
 
     public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName) => Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
     public ClipData? GetClip(string clipName) => AllClips.FirstOrDefault(c => c.Name.Equals(clipName, StringComparison.OrdinalIgnoreCase));
+    public SharpFM.Model.Parsing.ClipParseReport ValidateClipXml(string clipType, string xml) => SharpFM.Model.Parsing.ClipParseReport.Empty;
     public void CreateClip(string name, string clipType, string? xml = null) { }
     public bool RemoveClip(string clipName) => false;
     public void UpdateClipXml(string clipName, string xml, string originPluginId) { LastUpdatedXml = xml; LastOriginPluginId = originPluginId; }

--- a/tests/SharpFM.Tests/ClipTests.cs
+++ b/tests/SharpFM.Tests/ClipTests.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
 using System.Text;
 using SharpFM.Model;
 using SharpFM.Model.Parsing;
+using SharpFM.Model.Scripting;
+using SharpFM.Model.Validation;
 
 namespace SharpFM.Tests;
 
@@ -102,5 +105,64 @@ public class ClipTests
         Assert.Same(original.Parsed, renamed.Parsed);
         Assert.Equal("Y", renamed.Name);
         Assert.Equal(original.Xml, renamed.Xml);
+    }
+
+    [Fact]
+    public void FromXml_RunsSemanticValidators_AndFoldsDiagnosticsIntoReport()
+    {
+        var fake = new SeenItValidator();
+        using var _ = SemanticValidatorRegistry.OverrideForTest([fake]);
+
+        var clip = Clip.FromXml("X", "Mac-XMUNKNOWN", "<root/>");
+        var report = clip.Parsed.Report;
+
+        Assert.True(fake.Called);
+        Assert.Single(report.SemanticDiagnostics);
+        Assert.True(report.IsLossless);
+        Assert.False(report.IsSemanticallyValid);
+    }
+
+    [Fact]
+    public void FromEditor_RunsSemanticValidators_AndFoldsDiagnosticsIntoReport()
+    {
+        var fake = new SeenItValidator();
+        using var _ = SemanticValidatorRegistry.OverrideForTest([fake]);
+
+        var clip = Clip.FromEditor("X", "Mac-XMSS", "<root/>", new ScriptClipModel(new FmScript([])));
+        var report = clip.Parsed.Report;
+
+        Assert.True(fake.Called);
+        Assert.Single(report.SemanticDiagnostics);
+    }
+
+    [Fact]
+    public void FromXml_ParseFailure_DoesNotInvokeSemanticValidators()
+    {
+        var fake = new SeenItValidator();
+        using var _ = SemanticValidatorRegistry.OverrideForTest([fake]);
+
+        var clip = Clip.FromXml("X", "Mac-XMUNKNOWN", "<oops>");
+
+        Assert.IsType<ParseFailure>(clip.Parsed);
+        Assert.False(fake.Called);
+    }
+
+    private sealed class SeenItValidator : IClipSemanticValidator
+    {
+        public bool Called { get; private set; }
+        public IReadOnlyCollection<string> FormatIds => [IClipSemanticValidator.AllFormats];
+
+        public IReadOnlyList<ClipParseDiagnostic> Validate(ClipModel model)
+        {
+            Called = true;
+            return
+            [
+                new ClipParseDiagnostic(
+                    ParseDiagnosticKind.UnknownStep,
+                    ParseDiagnosticSeverity.Info,
+                    "/test",
+                    "seen"),
+            ];
+        }
     }
 }

--- a/tests/SharpFM.Tests/Parsing/ClipParseReportTests.cs
+++ b/tests/SharpFM.Tests/Parsing/ClipParseReportTests.cs
@@ -57,4 +57,43 @@ public class ClipParseReportTests
         Assert.Equal(first, report.Diagnostics[0]);
         Assert.Equal(second, report.Diagnostics[1]);
     }
+
+    [Fact]
+    public void SemanticDiagnostics_DefaultsToEmpty()
+    {
+        var report = new ClipParseReport([]);
+
+        Assert.Empty(report.SemanticDiagnostics);
+    }
+
+    [Fact]
+    public void Empty_SemanticDiagnostics_IsEmpty()
+    {
+        Assert.Empty(ClipParseReport.Empty.SemanticDiagnostics);
+    }
+
+    [Fact]
+    public void IsSemanticallyValid_TrueWhenSemanticDiagnosticsEmpty()
+    {
+        Assert.True(ClipParseReport.Empty.IsSemanticallyValid);
+    }
+
+    [Fact]
+    public void IsSemanticallyValid_FalseWhenAnySemanticDiagnostic()
+    {
+        var report = new ClipParseReport([])
+        {
+            SemanticDiagnostics =
+            [
+                new ClipParseDiagnostic(
+                    ParseDiagnosticKind.UnknownStep,
+                    ParseDiagnosticSeverity.Warning,
+                    "/fmxmlsnippet/Step[1]/Name",
+                    "variable name missing $ prefix"),
+            ],
+        };
+
+        Assert.False(report.IsSemanticallyValid);
+        Assert.True(report.IsLossless);
+    }
 }

--- a/tests/SharpFM.Tests/Validation/SemanticValidatorRegistryTests.cs
+++ b/tests/SharpFM.Tests/Validation/SemanticValidatorRegistryTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using SharpFM.Model.Parsing;
+using SharpFM.Model.Scripting;
+using SharpFM.Model.Validation;
+
+namespace SharpFM.Tests.Validation;
+
+public class SemanticValidatorRegistryTests
+{
+    [Fact]
+    public void BuiltIns_IsEmpty()
+    {
+        // No concrete rules ship in this PR; the framework is the contract.
+        Assert.Empty(SemanticValidatorRegistry.BuiltIns);
+    }
+
+    [Fact]
+    public void Run_WithEmptyRegistry_ReturnsEmpty()
+    {
+        var diags = SemanticValidatorRegistry.Run(
+            "Mac-XMSS",
+            new ScriptClipModel(new FmScript([])));
+
+        Assert.Empty(diags);
+    }
+
+    [Fact]
+    public void Run_DispatchesByFormatId()
+    {
+        var scriptOnly = new RecordingValidator("script-only", ["Mac-XMSS"]);
+        var tableOnly = new RecordingValidator("table-only", ["Mac-XMTB"]);
+        var wildcard = new RecordingValidator("wildcard", [IClipSemanticValidator.AllFormats]);
+        var validators = new IClipSemanticValidator[] { scriptOnly, tableOnly, wildcard };
+        var script = new ScriptClipModel(new FmScript([]));
+
+        var diags = SemanticValidatorRegistry.Run("Mac-XMSS", script, validators);
+
+        Assert.Equal(2, diags.Count);
+        Assert.True(scriptOnly.Invoked);
+        Assert.False(tableOnly.Invoked);
+        Assert.True(wildcard.Invoked);
+    }
+
+    [Fact]
+    public void Run_SkipsValidatorsThatReturnEmpty()
+    {
+        var silent = new RecordingValidator("silent", [IClipSemanticValidator.AllFormats], emit: false);
+        var loud = new RecordingValidator("loud", [IClipSemanticValidator.AllFormats]);
+
+        var diags = SemanticValidatorRegistry.Run(
+            "Mac-XMSS",
+            new ScriptClipModel(new FmScript([])),
+            [silent, loud]);
+
+        Assert.Single(diags);
+    }
+
+    private sealed class RecordingValidator(
+        string label,
+        IReadOnlyCollection<string> formats,
+        bool emit = true) : IClipSemanticValidator
+    {
+        public bool Invoked { get; private set; }
+        public IReadOnlyCollection<string> FormatIds => formats;
+
+        public IReadOnlyList<ClipParseDiagnostic> Validate(ClipModel model)
+        {
+            Invoked = true;
+            if (!emit) return [];
+            return
+            [
+                new ClipParseDiagnostic(
+                    ParseDiagnosticKind.UnknownStep,
+                    ParseDiagnosticSeverity.Info,
+                    "/test",
+                    label),
+            ];
+        }
+    }
+}

--- a/tests/SharpFM.Tests/ViewModels/ClipViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/ClipViewModelTests.cs
@@ -101,6 +101,45 @@ public class ClipViewModelTests
     }
 
     [Fact]
+    public void RenameTo_UpdatesUnderlyingClipName()
+    {
+        var vm = CreateScriptClip(WrapXml(""));
+
+        vm.RenameTo("Renamed");
+
+        Assert.Equal("Renamed", vm.Clip.Name);
+    }
+
+    [Fact]
+    public void RenameTo_RaisesPropertyChangedForClip()
+    {
+        var vm = CreateScriptClip(WrapXml(""));
+        var notified = false;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(ClipViewModel.Clip))
+            {
+                notified = true;
+            }
+        };
+
+        vm.RenameTo("Renamed");
+
+        Assert.True(notified);
+    }
+
+    [Fact]
+    public void RenameTo_ReusesCachedParse()
+    {
+        var vm = CreateScriptClip(WrapXml("<Step enable=\"True\" id=\"93\" name=\"Beep\"/>"));
+        var originalParsed = vm.Clip.Parsed;
+
+        vm.RenameTo("Renamed");
+
+        Assert.Same(originalParsed, vm.Clip.Parsed);
+    }
+
+    [Fact]
     public void IsDirty_FalseImmediatelyAfterConstruction()
     {
         var vm = CreateScriptClip(WrapXml("<Step enable=\"True\" id=\"93\" name=\"Beep\"/>"));

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -282,6 +282,7 @@ public class MainWindowViewModelTests
 #pragma warning restore CS0067
         public ILogger CreateLogger(string categoryName) => NullLogger.Instance;
         public Model.ClipData? GetClip(string clipName) => null;
+        public Model.Parsing.ClipParseReport ValidateClipXml(string clipType, string xml) => Model.Parsing.ClipParseReport.Empty;
         public void UpdateClipXml(string clipName, string xml, string originPluginId) { }
         public void CreateClip(string name, string clipType, string? xml = null) { }
         public bool RemoveClip(string clipName) => false;

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using SharpFM.Dialogs;
 using SharpFM.Plugin;
 using SharpFM.Plugin.UI;
 using SharpFM.Services;
@@ -38,13 +39,30 @@ public class MainWindowViewModelTests
 {
     private static MainWindowViewModel CreateVm(
         MockClipboardService? clipboard = null,
-        MockFolderService? folderService = null)
+        MockFolderService? folderService = null,
+        IInputPrompt? prompt = null)
     {
         var logger = NullLoggerFactory.Instance.CreateLogger<MainWindowViewModel>();
         return new MainWindowViewModel(
             logger,
             clipboard ?? new MockClipboardService(),
-            folderService ?? new MockFolderService());
+            folderService ?? new MockFolderService(),
+            prompt);
+    }
+
+    private sealed class FakeInputPrompt(string? answer) : IInputPrompt
+    {
+        public string? LastTitle { get; private set; }
+        public string? LastPrompt { get; private set; }
+        public string? LastDefault { get; private set; }
+
+        public Task<string?> PromptAsync(string title, string prompt, string defaultValue)
+        {
+            LastTitle = title;
+            LastPrompt = prompt;
+            LastDefault = defaultValue;
+            return Task.FromResult(answer);
+        }
     }
 
     [Fact]
@@ -95,6 +113,55 @@ public class MainWindowViewModelTests
         vm.SelectedClip = null;
         await vm.CopyAsClass();
         Assert.Equal("No clip selected", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task RenameSelectedClip_PromptsAndRenames()
+    {
+        var prompt = new FakeInputPrompt("Renamed");
+        var vm = CreateVm(prompt: prompt);
+        vm.NewScriptCommand();
+
+        await vm.RenameSelectedClip();
+
+        Assert.Equal("Renamed", vm.SelectedClip!.Clip.Name);
+        Assert.Equal("New Script", prompt.LastDefault);
+        Assert.Contains("Renamed", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task RenameSelectedClip_NoSelection_ShowsStatus()
+    {
+        var vm = CreateVm(prompt: new FakeInputPrompt("Whatever"));
+        vm.SelectedClip = null;
+
+        await vm.RenameSelectedClip();
+
+        Assert.Equal("No clip selected", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task RenameSelectedClip_BlankInput_KeepsExistingName()
+    {
+        var vm = CreateVm(prompt: new FakeInputPrompt("   "));
+        vm.NewScriptCommand();
+        var original = vm.SelectedClip!.Clip.Name;
+
+        await vm.RenameSelectedClip();
+
+        Assert.Equal(original, vm.SelectedClip!.Clip.Name);
+    }
+
+    [Fact]
+    public async Task RenameSelectedClip_CancelledPrompt_KeepsExistingName()
+    {
+        var vm = CreateVm(prompt: new FakeInputPrompt(null));
+        vm.NewScriptCommand();
+        var original = vm.SelectedClip!.Clip.Name;
+
+        await vm.RenameSelectedClip();
+
+        Assert.Equal(original, vm.SelectedClip!.Clip.Name);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #202.

Bundles the four follow-up items from #202:

1. **`ClipParseReport` on `ClipData`** — plugins can now read fidelity diagnostics without re-parsing via the new `ClipData.ParseReport` init-only property. `PluginHost` populates it at every `new ClipData` site from the live `Clip` aggregate's cached parse.

2. **`IPluginHost.ValidateClipXml(clipType, xml) → ClipParseReport`** — pure pre-flight validator routed through `ClipTypeRegistry.For(clipType).Parse(xml).Report`. No mutation, no UI-thread gating. Lets external callers inspect lossiness before pushing XML through `UpdateClipXml` / `UpdateSelectedClipXml`.

3. **Semantic-validator framework** (no rules) — new `SharpFM.Model.Validation` namespace with `IClipSemanticValidator` and `SemanticValidatorRegistry`. Wired into `Clip.FromXml` and `Clip.FromEditor` so diagnostics fold into a separate `ClipParseReport.SemanticDiagnostics` list. Structural and semantic axes stay distinct — `IsLossless` keeps its existing meaning, and a new `IsSemanticallyValid` mirrors it on the semantic side. Ships with `BuiltIns = []`; concrete rules land in follow-ups.

4. **`Clip.Rename` wired to a UI command** — new "Rename..." context-menu item on the clip tree, backed by `MainWindowViewModel.RenameSelectedClip`. Adds the `SharpFM.Dialogs` namespace (`IInputPrompt` + `InputDialog`) and fills in the previously-stubbed `IPluginHost.ShowInputDialogAsync` via the same plumbing.

Also fixes a pre-existing UX gap: right-clicking a clip in the tree now promotes that node into the active selection before the context menu opens, so Rename / Delete / Copy operate on the right-clicked clip rather than whatever was previously focused.

1345 tests pass (`dotnet test SharpFM.sln`).
