### PR TITLE
Derive paste clip name from FileMaker metadata

### DIFF
--- a/src/SharpFM.Model/ClipTypes/IClipTypeStrategy.cs
+++ b/src/SharpFM.Model/ClipTypes/IClipTypeStrategy.cs
@@ -29,4 +29,13 @@ public interface IClipTypeStrategy
     /// "new clip" flows in the host and by plugins.
     /// </summary>
     string DefaultXml(string clipName);
+
+    /// <summary>
+    /// Pull a clip-display-name hint out of <paramref name="xml"/> when the
+    /// wire format carries one (e.g. <c>&lt;Script name="…"&gt;</c> for
+    /// <c>Mac-XMSC</c>, <c>&lt;BaseTable name="…"&gt;</c> for <c>Mac-XMTB</c>).
+    /// Returns <c>null</c> for formats with no embedded name or when the
+    /// element is absent. Must not throw on malformed input.
+    /// </summary>
+    string? TryGetSourceName(string xml);
 }

--- a/src/SharpFM.Model/ClipTypes/LayoutClipStrategy.cs
+++ b/src/SharpFM.Model/ClipTypes/LayoutClipStrategy.cs
@@ -29,4 +29,6 @@ public sealed class LayoutClipStrategy : IClipTypeStrategy
 
     public string DefaultXml(string clipName) =>
         "<fmxmlsnippet type=\"FMObjectList\"></fmxmlsnippet>";
+
+    public string? TryGetSourceName(string xml) => null;
 }

--- a/src/SharpFM.Model/ClipTypes/OpaqueClipStrategy.cs
+++ b/src/SharpFM.Model/ClipTypes/OpaqueClipStrategy.cs
@@ -44,4 +44,6 @@ public sealed class OpaqueClipStrategy : IClipTypeStrategy
 
     public string DefaultXml(string clipName) =>
         "<fmxmlsnippet type=\"FMObjectList\"></fmxmlsnippet>";
+
+    public string? TryGetSourceName(string xml) => null;
 }

--- a/src/SharpFM.Model/ClipTypes/ScriptClipStrategy.cs
+++ b/src/SharpFM.Model/ClipTypes/ScriptClipStrategy.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
 using SharpFM.Model.Parsing;
 using SharpFM.Model.Scripting;
 
@@ -63,4 +66,17 @@ public sealed class ScriptClipStrategy : IClipTypeStrategy
 
     public string DefaultXml(string clipName) =>
         "<fmxmlsnippet type=\"FMObjectList\"></fmxmlsnippet>";
+
+    public string? TryGetSourceName(string xml)
+    {
+        try
+        {
+            var name = XDocument.Parse(xml).Descendants("Script").FirstOrDefault()?.Attribute("name")?.Value;
+            return string.IsNullOrEmpty(name) ? null : name;
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
+    }
 }

--- a/src/SharpFM.Model/ClipTypes/TableClipStrategy.cs
+++ b/src/SharpFM.Model/ClipTypes/TableClipStrategy.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
 using SharpFM.Model.Parsing;
 using SharpFM.Model.Schema;
 using SharpFM.Model.Scripting;
@@ -66,4 +69,17 @@ public sealed class TableClipStrategy : IClipTypeStrategy
         _wrapsBaseTable
             ? $"<fmxmlsnippet type=\"FMObjectList\"><BaseTable name=\"{XmlHelpers.XmlEscape(clipName)}\"></BaseTable></fmxmlsnippet>"
             : "<fmxmlsnippet type=\"FMObjectList\"></fmxmlsnippet>";
+
+    public string? TryGetSourceName(string xml)
+    {
+        try
+        {
+            var name = XDocument.Parse(xml).Descendants("BaseTable").FirstOrDefault()?.Attribute("name")?.Value;
+            return string.IsNullOrEmpty(name) ? null : name;
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
+    }
 }

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -334,6 +334,19 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
+    // Pick a clip name that doesn't collide with anything already loaded.
+    // Returns the input when it's free, otherwise appends "(2)", "(3)", … until
+    // a free slot is found.
+    private string UniqueClipName(string desired)
+    {
+        if (FileMakerClips.All(c => c.Clip.Name != desired)) return desired;
+        for (var n = 2; ; n++)
+        {
+            var candidate = $"{desired} ({n})";
+            if (FileMakerClips.All(c => c.Clip.Name != candidate)) return candidate;
+        }
+    }
+
     public async Task PasteFileMakerClipData()
     {
         try
@@ -354,6 +367,10 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
 
                 // don't add duplicates
                 if (FileMakerClips.Any(k => k.Clip.Xml == clip.Xml)) continue;
+
+                var sourceName = ClipTypeRegistry.For(format).TryGetSourceName(clip.Xml);
+                var desired = string.IsNullOrWhiteSpace(sourceName) ? "new-clip" : sourceName;
+                clip = clip.Rename(UniqueClipName(desired));
 
                 lastAdded = new ClipViewModel(clip);
                 FileMakerClips.Add(lastAdded);

--- a/tests/SharpFM.Tests/ClipTypes/LayoutClipStrategyTests.cs
+++ b/tests/SharpFM.Tests/ClipTypes/LayoutClipStrategyTests.cs
@@ -13,6 +13,15 @@ public class LayoutClipStrategyTests
     }
 
     [Fact]
+    public void TryGetSourceName_ReturnsNull()
+    {
+        var name = LayoutClipStrategy.Instance.TryGetSourceName(
+            "<fmxmlsnippet type=\"FMObjectList\"><Layout/></fmxmlsnippet>");
+
+        Assert.Null(name);
+    }
+
+    [Fact]
     public void Parse_ValidLayoutSnippet_ReturnsSuccess()
     {
         var result = LayoutClipStrategy.Instance.Parse(

--- a/tests/SharpFM.Tests/ClipTypes/OpaqueClipStrategyTests.cs
+++ b/tests/SharpFM.Tests/ClipTypes/OpaqueClipStrategyTests.cs
@@ -53,4 +53,12 @@ public class OpaqueClipStrategyTests
         var result = OpaqueClipStrategy.Instance.Parse(seed);
         Assert.IsType<ParseSuccess>(result);
     }
+
+    [Fact]
+    public void TryGetSourceName_ReturnsNull()
+    {
+        var name = OpaqueClipStrategy.Instance.TryGetSourceName("<root name=\"Whatever\"/>");
+
+        Assert.Null(name);
+    }
 }

--- a/tests/SharpFM.Tests/ClipTypes/ScriptClipStrategyTests.cs
+++ b/tests/SharpFM.Tests/ClipTypes/ScriptClipStrategyTests.cs
@@ -15,6 +15,41 @@ public class ScriptClipStrategyTests
     }
 
     [Fact]
+    public void TryGetSourceName_ReturnsScriptNameAttribute()
+    {
+        var name = ScriptClipStrategy.Script.TryGetSourceName(
+            "<fmxmlsnippet type=\"FMObjectList\"><Script name=\"FooBar\"></Script></fmxmlsnippet>");
+
+        Assert.Equal("FooBar", name);
+    }
+
+    [Fact]
+    public void TryGetSourceName_StepsClipWithoutScriptWrapper_ReturnsNull()
+    {
+        var name = ScriptClipStrategy.Steps.TryGetSourceName(
+            "<fmxmlsnippet type=\"FMObjectList\"><Step enable=\"True\" id=\"141\" name=\"Set Variable\"/></fmxmlsnippet>");
+
+        Assert.Null(name);
+    }
+
+    [Fact]
+    public void TryGetSourceName_MalformedXml_ReturnsNull()
+    {
+        var name = ScriptClipStrategy.Script.TryGetSourceName("<oops>");
+
+        Assert.Null(name);
+    }
+
+    [Fact]
+    public void TryGetSourceName_PreservesPunctuationInName()
+    {
+        var name = ScriptClipStrategy.Script.TryGetSourceName(
+            "<fmxmlsnippet type=\"FMObjectList\"><Script name=\"My &quot;favorite&quot; script\"></Script></fmxmlsnippet>");
+
+        Assert.Equal("My \"favorite\" script", name);
+    }
+
+    [Fact]
     public void Parse_EmptyScriptSnippet_ReturnsLosslessSuccess()
     {
         var result = ScriptClipStrategy.Steps.Parse(

--- a/tests/SharpFM.Tests/ClipTypes/TableClipStrategyTests.cs
+++ b/tests/SharpFM.Tests/ClipTypes/TableClipStrategyTests.cs
@@ -13,6 +13,32 @@ public class TableClipStrategyTests
     }
 
     [Fact]
+    public void TryGetSourceName_ReturnsBaseTableNameAttribute()
+    {
+        var name = TableClipStrategy.Table.TryGetSourceName(
+            "<fmxmlsnippet type=\"FMObjectList\"><BaseTable name=\"Customers\" id=\"1\"></BaseTable></fmxmlsnippet>");
+
+        Assert.Equal("Customers", name);
+    }
+
+    [Fact]
+    public void TryGetSourceName_FieldClipWithoutBaseTable_ReturnsNull()
+    {
+        var name = TableClipStrategy.Field.TryGetSourceName(
+            "<fmxmlsnippet type=\"FMObjectList\"><Field id=\"1\" name=\"ID\"/></fmxmlsnippet>");
+
+        Assert.Null(name);
+    }
+
+    [Fact]
+    public void TryGetSourceName_MalformedXml_ReturnsNull()
+    {
+        var name = TableClipStrategy.Table.TryGetSourceName("<oops>");
+
+        Assert.Null(name);
+    }
+
+    [Fact]
     public void Parse_ValidTable_ReturnsSuccess()
     {
         const string xml = """

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using SharpFM.Dialogs;
+using SharpFM.Model;
 using SharpFM.Plugin;
 using SharpFM.Plugin.UI;
 using SharpFM.Services;
@@ -197,6 +198,77 @@ public class MainWindowViewModelTests
         Assert.Equal(initialCount + 2, vm.FileMakerClips.Count);
         Assert.Same(vm.FileMakerClips[^1], vm.SelectedClip);
         Assert.Contains("Pasted 2 clip(s)", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task PasteFileMakerClipData_ScriptWithMetadataName_UsesMetadataAsClipName()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSC"] = BuildClipBytes(
+            "<fmxmlsnippet><Script name=\"OrderTotal\"></Script></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        vm.FileMakerClips.Clear();
+
+        await vm.PasteFileMakerClipData();
+
+        Assert.Equal("OrderTotal", vm.SelectedClip!.Clip.Name);
+    }
+
+    [Fact]
+    public async Task PasteFileMakerClipData_TableWithBaseTableName_UsesItAsClipName()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMTB"] = BuildClipBytes(
+            "<fmxmlsnippet><BaseTable name=\"Customers\"></BaseTable></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        vm.FileMakerClips.Clear();
+
+        await vm.PasteFileMakerClipData();
+
+        Assert.Equal("Customers", vm.SelectedClip!.Clip.Name);
+    }
+
+    [Fact]
+    public async Task PasteFileMakerClipData_NoMetadataName_FallsBackToNewClip()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSS"] = BuildClipBytes(
+            "<fmxmlsnippet type=\"FMObjectList\"><Step enable=\"True\" id=\"141\" name=\"Set Variable\"/></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        vm.FileMakerClips.Clear();
+
+        await vm.PasteFileMakerClipData();
+
+        Assert.Equal("new-clip", vm.SelectedClip!.Clip.Name);
+    }
+
+    [Fact]
+    public async Task PasteFileMakerClipData_CollidingName_AppendsNumericSuffix()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSC"] = BuildClipBytes(
+            "<fmxmlsnippet><Script name=\"OrderTotal\"></Script></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        vm.FileMakerClips.Clear();
+        vm.FileMakerClips.Add(new ClipViewModel(Clip.FromXml("OrderTotal", "Mac-XMSC", "<fmxmlsnippet/>")));
+
+        await vm.PasteFileMakerClipData();
+
+        Assert.Equal("OrderTotal (2)", vm.SelectedClip!.Clip.Name);
+    }
+
+    [Fact]
+    public async Task PasteFileMakerClipData_PreservesPunctuationInName()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSC"] = BuildClipBytes(
+            "<fmxmlsnippet><Script name=\"My &quot;favorite&quot; script\"></Script></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        vm.FileMakerClips.Clear();
+
+        await vm.PasteFileMakerClipData();
+
+        Assert.Equal("My \"favorite\" script", vm.SelectedClip!.Clip.Name);
     }
 
     private static byte[] BuildClipBytes(string xml)


### PR DESCRIPTION
Pasting a clip from FileMaker initialised the clip's name to the hardcoded `"new-clip"` string, even when the wire payload already carried the original name (`<Script name="…">` for Mac-XMSC, `<BaseTable name="…">` for Mac-XMTB). Every paste needed a manual rename to stay findable.

This change adds `string? TryGetSourceName(string xml)` to `IClipTypeStrategy`. Script and Table strategies extract the name attribute from their wrapper element; Layout and Opaque return `null`. `MainWindowViewModel.PasteFileMakerClipData` consults the strategy, falls back to `"new-clip"` when no name is available, and appends `" (2)"`, `" (3)"`, … on collision with an existing clip name.

1359 tests pass (`dotnet test SharpFM.sln`).