### PR TITLE
feat: rework clip catalog (group paste, folder metadata, panel polish)

### DIFF
--- a/src/SharpFM.Model/FolderData.cs
+++ b/src/SharpFM.Model/FolderData.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace SharpFM.Model;
+
+/// <summary>
+/// Data transfer object for folder-metadata persistence. Carries the FileMaker
+/// <c>&lt;Group&gt;</c> attributes that have no home on individual
+/// <see cref="ClipData"/> entries. An entry exists for every folder the user
+/// has materialized — including empty folders that contain no clips.
+/// </summary>
+/// <param name="Path">
+/// Hierarchy this folder lives at, as an ordered list of segment names. The
+/// final segment is the folder's own name. Empty paths are not valid.
+/// </param>
+public sealed record FolderData(IReadOnlyList<string> Path)
+{
+    /// <summary>
+    /// FileMaker <c>Group/@id</c>, preserved when the folder came from a paste.
+    /// Null for folders the user created locally; the host assigns an id when
+    /// the folder is copied back to FileMaker.
+    /// </summary>
+    public int? Id { get; init; }
+
+    /// <summary>
+    /// FileMaker <c>Group/@includeInMenu</c>. Defaults to <c>true</c>, matching
+    /// FileMaker's default for new groups.
+    /// </summary>
+    public bool IncludeInMenu { get; init; } = true;
+
+    /// <summary>
+    /// FileMaker <c>Group/@groupCollapsed</c>. Defaults to <c>false</c>; the UI
+    /// uses this to pre-collapse a pasted group on load.
+    /// </summary>
+    public bool GroupCollapsed { get; init; }
+}

--- a/src/SharpFM.Model/GroupPasteDecomposer.cs
+++ b/src/SharpFM.Model/GroupPasteDecomposer.cs
@@ -13,21 +13,31 @@ namespace SharpFM.Model;
 public sealed record GroupPasteEntry(string Name, string Xml, IReadOnlyList<string> FolderPath);
 
 /// <summary>
+/// Decomposed view of an <c>fmxmlsnippet</c> Group paste: the per-script
+/// entries plus folder metadata captured from every enclosing
+/// <c>&lt;Group&gt;</c>.
+/// </summary>
+public sealed record GroupPasteResult(
+    IReadOnlyList<GroupPasteEntry> Entries,
+    IReadOnlyList<FolderData> Folders);
+
+/// <summary>
 /// Decomposes a FileMaker script-folder paste (an <c>fmxmlsnippet</c> whose
 /// root contains <c>&lt;Group&gt;</c> elements) into one entry per
 /// <c>&lt;Script&gt;</c>, preserving the Group hierarchy as
-/// <see cref="GroupPasteEntry.FolderPath"/>.
+/// <see cref="GroupPasteEntry.FolderPath"/> and the Group attributes as
+/// <see cref="FolderData"/>.
 /// </summary>
 public static class GroupPasteDecomposer
 {
     /// <summary>
-    /// Returns one entry per Script when the snippet contains any
+    /// Returns the entries and folder metadata when the snippet contains any
     /// <c>&lt;Group&gt;</c> at the top level, or <c>null</c> when the snippet
     /// is a plain single-clip paste. Scripts that sit at the root alongside a
     /// Group are emitted with an empty <see cref="GroupPasteEntry.FolderPath"/>
     /// so the caller can place them at the paste root.
     /// </summary>
-    public static IReadOnlyList<GroupPasteEntry>? TryDecompose(string xml)
+    public static GroupPasteResult? TryDecompose(string xml)
     {
         XDocument doc;
         try
@@ -47,11 +57,16 @@ public static class GroupPasteDecomposer
         if (!hasGroup) return null;
 
         var entries = new List<GroupPasteEntry>();
-        Walk(root, new List<string>(), entries);
-        return entries;
+        var folders = new List<FolderData>();
+        Walk(root, new List<string>(), entries, folders);
+        return new GroupPasteResult(entries, folders);
     }
 
-    private static void Walk(XElement parent, List<string> folderPath, List<GroupPasteEntry> entries)
+    private static void Walk(
+        XElement parent,
+        List<string> folderPath,
+        List<GroupPasteEntry> entries,
+        List<FolderData> folders)
     {
         foreach (var child in parent.Elements())
         {
@@ -63,7 +78,8 @@ public static class GroupPasteDecomposer
                 case "Group":
                     var name = child.Attribute("name")?.Value ?? "Group";
                     folderPath.Add(name);
-                    Walk(child, folderPath, entries);
+                    folders.Add(BuildFolder(child, folderPath));
+                    Walk(child, folderPath, entries, folders);
                     folderPath.RemoveAt(folderPath.Count - 1);
                     break;
             }
@@ -82,5 +98,27 @@ public static class GroupPasteDecomposer
         var xml = new XDocument(snippet).ToString(SaveOptions.DisableFormatting);
 
         return new GroupPasteEntry(name, xml, folderPath.ToArray());
+    }
+
+    private static FolderData BuildFolder(XElement group, List<string> folderPath)
+    {
+        int? id = null;
+        if (int.TryParse(group.Attribute("id")?.Value, out var parsedId))
+        {
+            id = parsedId;
+        }
+
+        return new FolderData(folderPath.ToArray())
+        {
+            Id = id,
+            IncludeInMenu = ParseFmBool(group.Attribute("includeInMenu"), defaultValue: true),
+            GroupCollapsed = ParseFmBool(group.Attribute("groupCollapsed"), defaultValue: false),
+        };
+    }
+
+    private static bool ParseFmBool(XAttribute? attribute, bool defaultValue)
+    {
+        if (attribute is null) return defaultValue;
+        return string.Equals(attribute.Value, "True", System.StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/SharpFM.Model/GroupPasteDecomposer.cs
+++ b/src/SharpFM.Model/GroupPasteDecomposer.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace SharpFM.Model;
+
+/// <summary>
+/// One script extracted from a FileMaker Group paste, paired with the folder
+/// path it should land in. <see cref="Xml"/> is a full <c>&lt;fmxmlsnippet&gt;</c>
+/// envelope wrapping a single <c>&lt;Script&gt;</c>, ready to be re-pasted back
+/// to FileMaker as a single clip.
+/// </summary>
+public sealed record GroupPasteEntry(string Name, string Xml, IReadOnlyList<string> FolderPath);
+
+/// <summary>
+/// Decomposes a FileMaker script-folder paste (an <c>fmxmlsnippet</c> whose
+/// root contains <c>&lt;Group&gt;</c> elements) into one entry per
+/// <c>&lt;Script&gt;</c>, preserving the Group hierarchy as
+/// <see cref="GroupPasteEntry.FolderPath"/>.
+/// </summary>
+public static class GroupPasteDecomposer
+{
+    /// <summary>
+    /// Returns one entry per Script when the snippet contains any
+    /// <c>&lt;Group&gt;</c> at the top level, or <c>null</c> when the snippet
+    /// is a plain single-clip paste. Scripts that sit at the root alongside a
+    /// Group are emitted with an empty <see cref="GroupPasteEntry.FolderPath"/>
+    /// so the caller can place them at the paste root.
+    /// </summary>
+    public static IReadOnlyList<GroupPasteEntry>? TryDecompose(string xml)
+    {
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(xml);
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
+
+        var root = doc.Root;
+        if (root is null) return null;
+
+        var hasGroup = false;
+        foreach (var _ in root.Elements("Group")) { hasGroup = true; break; }
+        if (!hasGroup) return null;
+
+        var entries = new List<GroupPasteEntry>();
+        Walk(root, new List<string>(), entries);
+        return entries;
+    }
+
+    private static void Walk(XElement parent, List<string> folderPath, List<GroupPasteEntry> entries)
+    {
+        foreach (var child in parent.Elements())
+        {
+            switch (child.Name.LocalName)
+            {
+                case "Script":
+                    entries.Add(BuildEntry(child, folderPath));
+                    break;
+                case "Group":
+                    var name = child.Attribute("name")?.Value ?? "Group";
+                    folderPath.Add(name);
+                    Walk(child, folderPath, entries);
+                    folderPath.RemoveAt(folderPath.Count - 1);
+                    break;
+            }
+        }
+    }
+
+    private static GroupPasteEntry BuildEntry(XElement script, List<string> folderPath)
+    {
+        var name = script.Attribute("name")?.Value;
+        if (string.IsNullOrEmpty(name)) name = "new-clip";
+
+        var snippet = new XElement("fmxmlsnippet",
+            new XAttribute("type", "FMObjectList"),
+            new XElement(script));
+
+        var xml = new XDocument(snippet).ToString(SaveOptions.DisableFormatting);
+
+        return new GroupPasteEntry(name, xml, folderPath.ToArray());
+    }
+}

--- a/src/SharpFM.Model/IClipRepository.cs
+++ b/src/SharpFM.Model/IClipRepository.cs
@@ -37,6 +37,22 @@ public interface IClipRepository
     Task SaveClipsAsync(IReadOnlyList<ClipData> clips);
 
     /// <summary>
+    /// Load folder metadata records — one per materialized folder (including
+    /// empty ones). Default implementation returns an empty list for backends
+    /// that don't model folders independently of clip paths.
+    /// </summary>
+    Task<IReadOnlyList<FolderData>> LoadFoldersAsync() =>
+        Task.FromResult<IReadOnlyList<FolderData>>([]);
+
+    /// <summary>
+    /// Save folder metadata. The implementation should handle creates,
+    /// updates, and deletes (folders not in the list should be removed).
+    /// Default implementation is a no-op for backends that infer folders from
+    /// clip paths only.
+    /// </summary>
+    Task SaveFoldersAsync(IReadOnlyList<FolderData> folders) => Task.CompletedTask;
+
+    /// <summary>
     /// Open a location picker and switch to the selected location.
     /// Only called if <see cref="SupportsLocationPicker"/> is true.
     /// Returns the display string for the new location, or null if cancelled.

--- a/src/SharpFM/MainWindow.axaml
+++ b/src/SharpFM/MainWindow.axaml
@@ -159,79 +159,89 @@
 
                 <!--  Left panel: Clips navigation with Fluent 2 surface treatment  -->
                 <Border Grid.Column="0" Classes="Fluent2SurfaceElevated">
-                    <ScrollViewer>
-                        <StackPanel Margin="16" Spacing="16">
-                            <!--  Search section  -->
-                            <StackPanel Spacing="8">
-                                <TextBlock Classes="Fluent2Subtitle" Text="Search Clips" />
-                                <TextBox
-                                    Classes="Fluent2"
-                                    Text="{Binding SearchText}"
-                                    Watermark="Type to search clips..." />
-                            </StackPanel>
-
-                            <!--
-                                Clips tree section. Mirrors the repository's folder
-                                hierarchy (ClipViewModel.FolderPath). Single-tap a
-                                clip for a preview tab, double-tap for a permanent
-                                tab.
-                            -->
-                            <StackPanel Spacing="8">
-                                <TextBlock Classes="Fluent2Subtitle" Text="Available Clips" />
-                                <TreeView
-                                    x:Name="clipsTreeView"
-                                    ContextRequested="ClipsTree_ContextRequested"
-                                    DoubleTapped="ClipsTree_DoubleTapped"
-                                    ItemsSource="{Binding RootNodes}"
-                                    Tapped="ClipsTree_Tapped">
-                                    <TreeView.ContextMenu>
-                                        <ContextMenu>
-                                            <MenuItem Command="{Binding NewScriptCommand}" Header="New Script (whole script)" />
-                                            <MenuItem Command="{Binding NewScriptStepsCommand}" Header="New Script Steps (lines only)" />
-                                            <MenuItem Command="{Binding NewTableCommand}" Header="New Table" />
-                                            <MenuItem Command="{Binding NewFolderCommand}" Header="New Folder..." />
-                                            <Separator />
-                                            <MenuItem Command="{Binding PasteFileMakerClipData}" Header="Paste from FileMaker" />
-                                            <Separator />
-                                            <MenuItem Command="{Binding CopySelectedToClip}" Header="Copy to FileMaker" />
-                                            <MenuItem Command="{Binding CopyAsScript}" Header="Copy as Script (whole script)" />
-                                            <MenuItem Command="{Binding CopyAsScriptSteps}" Header="Copy as Script Steps (lines only)" />
-                                            <MenuItem Command="{Binding CopyAsClass}" Header="Copy as C# Class" />
-                                            <Separator />
-                                            <MenuItem Command="{Binding RenameSelectedClip}" Header="Rename..." />
-                                            <MenuItem Command="{Binding DeleteSelectedClip}" Header="Delete Clip" />
-                                        </ContextMenu>
-                                    </TreeView.ContextMenu>
-                                    <TreeView.DataTemplates>
-                                        <TreeDataTemplate DataType="vm:ClipTreeNodeViewModel" ItemsSource="{Binding Children}">
-                                            <StackPanel Orientation="Horizontal" Spacing="6">
-                                                <TextBlock
-                                                    FontWeight="SemiBold"
-                                                    IsVisible="{Binding IsFolder}"
-                                                    Text="{Binding Name}" />
-                                                <StackPanel
-                                                    IsVisible="{Binding IsClip}"
-                                                    Orientation="Horizontal"
-                                                    Spacing="6">
-                                                    <TextBlock Text="{Binding Clip.Clip.Name}" />
-                                                    <TextBlock
-                                                        Classes="Fluent2Caption"
-                                                        Opacity="0.6"
-                                                        Text="{Binding Clip.ClipTypeDisplay}" />
-                                                    <TextBlock
-                                                        Classes="Fluent2Caption"
-                                                        Foreground="DarkOrange"
-                                                        IsVisible="{Binding !Clip.IsLossless}"
-                                                        Text="!"
-                                                        ToolTip.Tip="This clip's XML did not round-trip cleanly through the domain model. See the status bar for details when selected." />
-                                                </StackPanel>
-                                            </StackPanel>
-                                        </TreeDataTemplate>
-                                    </TreeView.DataTemplates>
-                                </TreeView>
-                            </StackPanel>
+                    <!--
+                        DockPanel keeps the search/header rows docked at the top
+                        and lets the TreeView consume all remaining height so the
+                        empty space below the last node is part of the tree's hit
+                        area (root-targeted right-click).
+                    -->
+                    <DockPanel Margin="16" LastChildFill="True">
+                        <!--  Search section  -->
+                        <StackPanel
+                            Margin="0,0,0,16"
+                            DockPanel.Dock="Top"
+                            Spacing="8">
+                            <TextBlock Classes="Fluent2Subtitle" Text="Search Clips" />
+                            <TextBox
+                                Classes="Fluent2"
+                                Text="{Binding SearchText}"
+                                Watermark="Type to search clips..." />
                         </StackPanel>
-                    </ScrollViewer>
+
+                        <TextBlock
+                            Margin="0,0,0,8"
+                            Classes="Fluent2Subtitle"
+                            DockPanel.Dock="Top"
+                            Text="Available Clips" />
+
+                        <!--
+                            Clips tree section. Mirrors the repository's folder
+                            hierarchy (ClipViewModel.FolderPath). Single-tap a
+                            clip for a preview tab, double-tap for a permanent
+                            tab.
+                        -->
+                        <TreeView
+                            x:Name="clipsTreeView"
+                            ContextRequested="ClipsTree_ContextRequested"
+                            DoubleTapped="ClipsTree_DoubleTapped"
+                            ItemsSource="{Binding RootNodes}"
+                            Tapped="ClipsTree_Tapped">
+                            <TreeView.ContextMenu>
+                                <ContextMenu>
+                                    <MenuItem Command="{Binding NewScriptCommand}" Header="New Script (whole script)" />
+                                    <MenuItem Command="{Binding NewScriptStepsCommand}" Header="New Script Steps (lines only)" />
+                                    <MenuItem Command="{Binding NewTableCommand}" Header="New Table" />
+                                    <MenuItem Command="{Binding NewFolderCommand}" Header="New Folder..." />
+                                    <Separator />
+                                    <MenuItem Command="{Binding PasteFileMakerClipData}" Header="Paste from FileMaker" />
+                                    <Separator />
+                                    <MenuItem Command="{Binding CopySelectedToClip}" Header="Copy to FileMaker" />
+                                    <MenuItem Command="{Binding CopyAsScript}" Header="Copy as Script (whole script)" />
+                                    <MenuItem Command="{Binding CopyAsScriptSteps}" Header="Copy as Script Steps (lines only)" />
+                                    <MenuItem Command="{Binding CopyAsClass}" Header="Copy as C# Class" />
+                                    <Separator />
+                                    <MenuItem Command="{Binding RenameSelectedClip}" Header="Rename..." />
+                                    <MenuItem Command="{Binding DeleteSelectedClip}" Header="Delete Clip" />
+                                </ContextMenu>
+                            </TreeView.ContextMenu>
+                            <TreeView.DataTemplates>
+                                <TreeDataTemplate DataType="vm:ClipTreeNodeViewModel" ItemsSource="{Binding Children}">
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                        <TextBlock
+                                            FontWeight="SemiBold"
+                                            IsVisible="{Binding IsFolder}"
+                                            Text="{Binding Name}" />
+                                        <StackPanel
+                                            IsVisible="{Binding IsClip}"
+                                            Orientation="Horizontal"
+                                            Spacing="6">
+                                            <TextBlock Text="{Binding Clip.Clip.Name}" />
+                                            <TextBlock
+                                                Classes="Fluent2Caption"
+                                                Opacity="0.6"
+                                                Text="{Binding Clip.ClipTypeDisplay}" />
+                                            <TextBlock
+                                                Classes="Fluent2Caption"
+                                                Foreground="DarkOrange"
+                                                IsVisible="{Binding !Clip.IsLossless}"
+                                                Text="!"
+                                                ToolTip.Tip="This clip's XML did not round-trip cleanly through the domain model. See the status bar for details when selected." />
+                                        </StackPanel>
+                                    </StackPanel>
+                                </TreeDataTemplate>
+                            </TreeView.DataTemplates>
+                        </TreeView>
+                    </DockPanel>
                 </Border>
 
                 <!--  Splitter space  -->

--- a/src/SharpFM/MainWindow.axaml
+++ b/src/SharpFM/MainWindow.axaml
@@ -35,8 +35,9 @@
             <MenuItem Header="_File">
                 <MenuItem
                     Command="{Binding NewScriptCommand}"
-                    Header="New Script"
+                    Header="New Script (whole script)"
                     InputGesture="Ctrl+N" />
+                <MenuItem Command="{Binding NewScriptStepsCommand}" Header="New Script Steps (lines only)" />
                 <MenuItem
                     Command="{Binding NewTableCommand}"
                     Header="New Table"
@@ -65,6 +66,7 @@
                 <Separator />
                 <MenuItem Command="{Binding CopyAsClass}" Header="Copy as C# Class" />
                 <Separator />
+                <MenuItem Command="{Binding RenameSelectedClip}" Header="Rename..." />
                 <MenuItem Command="{Binding DeleteSelectedClip}" Header="Delete Clip" />
             </MenuItem>
             <MenuItem Header="_Tools">
@@ -184,12 +186,18 @@
                                     Tapped="ClipsTree_Tapped">
                                     <TreeView.ContextMenu>
                                         <ContextMenu>
+                                            <MenuItem Command="{Binding NewScriptCommand}" Header="New Script (whole script)" />
+                                            <MenuItem Command="{Binding NewScriptStepsCommand}" Header="New Script Steps (lines only)" />
+                                            <MenuItem Command="{Binding NewTableCommand}" Header="New Table" />
+                                            <MenuItem Command="{Binding NewFolderCommand}" Header="New Folder..." />
+                                            <Separator />
+                                            <MenuItem Command="{Binding PasteFileMakerClipData}" Header="Paste from FileMaker" />
+                                            <Separator />
                                             <MenuItem Command="{Binding CopySelectedToClip}" Header="Copy to FileMaker" />
-                                            <MenuItem Command="{Binding CopyAsScript}" Header="Copy as Script" />
-                                            <MenuItem Command="{Binding CopyAsScriptSteps}" Header="Copy as Script Steps" />
+                                            <MenuItem Command="{Binding CopyAsScript}" Header="Copy as Script (whole script)" />
+                                            <MenuItem Command="{Binding CopyAsScriptSteps}" Header="Copy as Script Steps (lines only)" />
                                             <MenuItem Command="{Binding CopyAsClass}" Header="Copy as C# Class" />
                                             <Separator />
-                                            <MenuItem Command="{Binding NewFolderCommand}" Header="New Folder..." />
                                             <MenuItem Command="{Binding RenameSelectedClip}" Header="Rename..." />
                                             <MenuItem Command="{Binding DeleteSelectedClip}" Header="Delete Clip" />
                                         </ContextMenu>

--- a/src/SharpFM/MainWindow.axaml
+++ b/src/SharpFM/MainWindow.axaml
@@ -41,6 +41,7 @@
                     Command="{Binding NewTableCommand}"
                     Header="New Table"
                     InputGesture="Ctrl+Shift+N" />
+                <MenuItem Command="{Binding NewFolderCommand}" Header="New Folder..." />
                 <Separator />
                 <MenuItem Command="{Binding OpenFolderPicker}" Header="Open Folder..." />
                 <MenuItem
@@ -188,6 +189,7 @@
                                             <MenuItem Command="{Binding CopyAsScriptSteps}" Header="Copy as Script Steps" />
                                             <MenuItem Command="{Binding CopyAsClass}" Header="Copy as C# Class" />
                                             <Separator />
+                                            <MenuItem Command="{Binding NewFolderCommand}" Header="New Folder..." />
                                             <MenuItem Command="{Binding RenameSelectedClip}" Header="Rename..." />
                                             <MenuItem Command="{Binding DeleteSelectedClip}" Header="Delete Clip" />
                                         </ContextMenu>

--- a/src/SharpFM/MainWindow.axaml
+++ b/src/SharpFM/MainWindow.axaml
@@ -196,6 +196,17 @@
                             DoubleTapped="ClipsTree_DoubleTapped"
                             ItemsSource="{Binding RootNodes}"
                             Tapped="ClipsTree_Tapped">
+                            <!--
+                                Bind TreeViewItem.IsExpanded two-way to the VM so the
+                                tree honours ClipTreeNodeViewModel.IsExpanded (default
+                                true) instead of collapsing every node on rebuild,
+                                and so the user's chevron clicks flow back to the VM.
+                            -->
+                            <TreeView.Styles>
+                                <Style x:DataType="vm:ClipTreeNodeViewModel" Selector="TreeViewItem">
+                                    <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
+                                </Style>
+                            </TreeView.Styles>
                             <TreeView.ContextMenu>
                                 <ContextMenu>
                                     <MenuItem Command="{Binding NewScriptCommand}" Header="New Script (whole script)" />

--- a/src/SharpFM/MainWindow.axaml.cs
+++ b/src/SharpFM/MainWindow.axaml.cs
@@ -236,12 +236,17 @@ public partial class MainWindow : Window
 
     // Right-click bypasses the Tapped handler, so the context menu would
     // otherwise operate on whatever was previously selected. Promote the
-    // right-clicked node into the active selection before the menu opens.
+    // right-clicked node into the active selection before the menu opens —
+    // and treat a click in the empty area as "select the repository root".
     private void ClipsTree_ContextRequested(object? sender, ContextRequestedEventArgs e)
     {
         if (DataContext is not MainWindowViewModel vm) return;
         var node = FindClipNode(e.Source);
-        if (node is null) return;
+        if (node is null)
+        {
+            vm.OpenFolderAsSelection([]);
+            return;
+        }
         if (node.Clip is not null)
         {
             vm.OpenClipAsPreview(node.Clip);

--- a/src/SharpFM/MainWindow.axaml.cs
+++ b/src/SharpFM/MainWindow.axaml.cs
@@ -225,8 +225,13 @@ public partial class MainWindow : Window
     {
         if (DataContext is not MainWindowViewModel vm) return;
         var node = FindClipNode(e.Source);
-        if (node?.Clip is null) return;
-        vm.OpenClipAsPreview(node.Clip);
+        if (node is null) return;
+        if (node.Clip is not null)
+        {
+            vm.OpenClipAsPreview(node.Clip);
+            return;
+        }
+        vm.OpenFolderAsSelection(node.Path);
     }
 
     // Right-click bypasses the Tapped handler, so the context menu would
@@ -236,8 +241,13 @@ public partial class MainWindow : Window
     {
         if (DataContext is not MainWindowViewModel vm) return;
         var node = FindClipNode(e.Source);
-        if (node?.Clip is null) return;
-        vm.OpenClipAsPreview(node.Clip);
+        if (node is null) return;
+        if (node.Clip is not null)
+        {
+            vm.OpenClipAsPreview(node.Clip);
+            return;
+        }
+        vm.OpenFolderAsSelection(node.Path);
     }
 
     private void ClipsTree_DoubleTapped(object? sender, TappedEventArgs e)

--- a/src/SharpFM/Models/ClipRepository.cs
+++ b/src/SharpFM/Models/ClipRepository.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using NLog;
 using SharpFM.Model;
@@ -11,11 +12,31 @@ namespace SharpFM.Models;
 /// <summary>
 /// File-system-based clip repository. Stores each clip as a file in a directory
 /// tree. Subdirectories map one-to-one to <see cref="ClipData.FolderPath"/>
-/// segments.
+/// segments. Per-folder metadata (FileMaker Group id, includeInMenu,
+/// groupCollapsed) is persisted in a <see cref="FolderMarkerFileName"/> sidecar
+/// inside each folder; an "empty folder" is a directory that contains only the
+/// sidecar.
 /// </summary>
 public class ClipRepository : IClipRepository
 {
     private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+
+    /// <summary>Sidecar filename used to store folder metadata and to mark
+    /// empty folders so the orphan sweep doesn't reclaim them.</summary>
+    public const string FolderMarkerFileName = ".sharpfm-folder.json";
+
+    private static readonly JsonSerializerOptions FolderJsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private sealed record FolderMarker
+    {
+        public int? Id { get; init; }
+        public bool IncludeInMenu { get; init; } = true;
+        public bool GroupCollapsed { get; init; }
+    }
 
     public string ProviderName => "Local Files";
 
@@ -49,6 +70,7 @@ public class ClipRepository : IClipRepository
             {
                 var fi = new FileInfo(clipFile);
                 if (string.IsNullOrEmpty(fi.Extension)) continue;
+                if (string.Equals(fi.Name, FolderMarkerFileName, StringComparison.OrdinalIgnoreCase)) continue;
 
                 var folderPath = GetRelativeFolderSegments(root.FullName, fi.Directory!.FullName);
 
@@ -91,8 +113,14 @@ public class ClipRepository : IClipRepository
         }
 
         // Remove files for clips that no longer exist (anywhere in the tree).
+        // Folder marker files are preserved by SaveFoldersAsync — they belong
+        // to the folder, not to any individual clip.
         foreach (var file in Directory.EnumerateFiles(ClipPath, "*", SearchOption.AllDirectories))
         {
+            if (string.Equals(Path.GetFileName(file), FolderMarkerFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
             var relative = Path.GetRelativePath(ClipPath, file);
             if (!activeRelativePaths.Contains(relative))
             {
@@ -100,7 +128,83 @@ public class ClipRepository : IClipRepository
             }
         }
 
-        // Clean up any now-empty subdirectories (bottom-up).
+        PruneEmptyDirectories();
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<FolderData>> LoadFoldersAsync()
+    {
+        var folders = new List<FolderData>();
+        var root = new DirectoryInfo(ClipPath);
+
+        foreach (var markerPath in Directory.EnumerateFiles(ClipPath, FolderMarkerFileName, SearchOption.AllDirectories))
+        {
+            try
+            {
+                var fi = new FileInfo(markerPath);
+                var path = GetRelativeFolderSegments(root.FullName, fi.Directory!.FullName);
+                if (path.Count == 0) continue;
+
+                var marker = JsonSerializer.Deserialize<FolderMarker>(File.ReadAllText(markerPath), FolderJsonOptions)
+                             ?? new FolderMarker();
+
+                folders.Add(new FolderData(path)
+                {
+                    Id = marker.Id,
+                    IncludeInMenu = marker.IncludeInMenu,
+                    GroupCollapsed = marker.GroupCollapsed,
+                });
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to load folder marker: {File}", markerPath);
+            }
+        }
+
+        return Task.FromResult<IReadOnlyList<FolderData>>(folders);
+    }
+
+    public Task SaveFoldersAsync(IReadOnlyList<FolderData> folders)
+    {
+        var activeMarkerPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var folder in folders)
+        {
+            var safeSegments = SanitizeFolderPath(folder.Path);
+            if (safeSegments.Count == 0) continue;
+
+            var targetDir = Path.Combine(new[] { ClipPath }.Concat(safeSegments).ToArray());
+            Directory.CreateDirectory(targetDir);
+
+            var marker = new FolderMarker
+            {
+                Id = folder.Id,
+                IncludeInMenu = folder.IncludeInMenu,
+                GroupCollapsed = folder.GroupCollapsed,
+            };
+
+            var markerPath = Path.Combine(targetDir, FolderMarkerFileName);
+            File.WriteAllText(markerPath, JsonSerializer.Serialize(marker, FolderJsonOptions));
+            activeMarkerPaths.Add(markerPath);
+        }
+
+        // Remove orphan marker files. Empty directories are reclaimed below.
+        foreach (var marker in Directory.EnumerateFiles(ClipPath, FolderMarkerFileName, SearchOption.AllDirectories))
+        {
+            if (!activeMarkerPaths.Contains(marker))
+            {
+                File.Delete(marker);
+            }
+        }
+
+        PruneEmptyDirectories();
+
+        return Task.CompletedTask;
+    }
+
+    private void PruneEmptyDirectories()
+    {
         foreach (var dir in Directory.EnumerateDirectories(ClipPath, "*", SearchOption.AllDirectories)
             .OrderByDescending(d => d.Length))
         {
@@ -110,8 +214,6 @@ public class ClipRepository : IClipRepository
                 catch (IOException) { /* best-effort */ }
             }
         }
-
-        return Task.CompletedTask;
     }
 
     public Task<string?> PickLocationAsync()

--- a/src/SharpFM/Models/ClipRepository.cs
+++ b/src/SharpFM/Models/ClipRepository.cs
@@ -75,7 +75,7 @@ public class ClipRepository : IClipRepository
                 var folderPath = GetRelativeFolderSegments(root.FullName, fi.Directory!.FullName);
 
                 clips.Add(new ClipData(
-                    Name: Path.GetFileNameWithoutExtension(fi.Name),
+                    Name: DecodeName(Path.GetFileNameWithoutExtension(fi.Name)),
                     ClipType: fi.Extension.TrimStart('.'),
                     Xml: File.ReadAllText(clipFile))
                 {
@@ -104,7 +104,7 @@ public class ClipRepository : IClipRepository
 
             Directory.CreateDirectory(targetDir);
 
-            var fileName = $"{clip.Name}.{clip.ClipType}";
+            var fileName = $"{EncodeName(clip.Name)}.{clip.ClipType}";
             var clipPath = Path.Combine(targetDir, fileName);
             File.WriteAllText(clipPath, clip.Xml);
 
@@ -227,12 +227,16 @@ public class ClipRepository : IClipRepository
     {
         var rel = Path.GetRelativePath(root, directory);
         if (string.IsNullOrEmpty(rel) || rel == ".") return [];
-        return rel.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+        var raw = rel.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
             StringSplitOptions.RemoveEmptyEntries);
+        var decoded = new string[raw.Length];
+        for (var i = 0; i < raw.Length; i++) decoded[i] = DecodeName(raw[i]);
+        return decoded;
     }
 
-    // Reject traversal/rooted segments; repositories are logical stores and
-    // must not escape their root no matter what a misbehaving provider sends.
+    // Reject traversal segments (security) and percent-encode any character
+    // the filesystem rejects so FileMaker names containing '/' or ':' survive
+    // the round-trip instead of being silently dropped.
     private static IReadOnlyList<string> SanitizeFolderPath(IReadOnlyList<string> segments)
     {
         if (segments is null || segments.Count == 0) return [];
@@ -241,9 +245,69 @@ public class ClipRepository : IClipRepository
         {
             if (string.IsNullOrWhiteSpace(raw)) continue;
             if (raw == "." || raw == "..") continue;
-            if (raw.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0) continue;
-            safe.Add(raw);
+            safe.Add(EncodeName(raw));
         }
         return safe;
+    }
+
+    private static readonly char[] InvalidNameChars = Path.GetInvalidFileNameChars();
+
+    /// <summary>
+    /// Percent-encode characters the filesystem rejects (path separators,
+    /// reserved chars, control codes) plus '%' itself so encoding is reversible.
+    /// Output is plain ASCII and safe to embed in any cross-platform filename.
+    /// </summary>
+    internal static string EncodeName(string raw)
+    {
+        var needsEncoding = false;
+        for (var i = 0; i < raw.Length; i++)
+        {
+            if (raw[i] == '%' || Array.IndexOf(InvalidNameChars, raw[i]) >= 0)
+            {
+                needsEncoding = true;
+                break;
+            }
+        }
+        if (!needsEncoding) return raw;
+
+        var sb = new System.Text.StringBuilder(raw.Length + 8);
+        foreach (var ch in raw)
+        {
+            if (ch == '%' || Array.IndexOf(InvalidNameChars, ch) >= 0)
+            {
+                sb.Append('%');
+                sb.Append(((int)ch).ToString("X2", System.Globalization.CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                sb.Append(ch);
+            }
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Reverse of <see cref="EncodeName"/>. Unrecognised '%' triplets pass through unchanged.</summary>
+    internal static string DecodeName(string encoded)
+    {
+        if (encoded.IndexOf('%') < 0) return encoded;
+
+        var sb = new System.Text.StringBuilder(encoded.Length);
+        for (var i = 0; i < encoded.Length; i++)
+        {
+            if (encoded[i] == '%' && i + 2 < encoded.Length
+                && int.TryParse(encoded.AsSpan(i + 1, 2),
+                    System.Globalization.NumberStyles.HexNumber,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var code))
+            {
+                sb.Append((char)code);
+                i += 2;
+            }
+            else
+            {
+                sb.Append(encoded[i]);
+            }
+        }
+        return sb.ToString();
     }
 }

--- a/src/SharpFM/ViewModels/ClipTreeNodeViewModel.cs
+++ b/src/SharpFM/ViewModels/ClipTreeNodeViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using SharpFM.Model;
 
 namespace SharpFM.ViewModels;
 
@@ -28,6 +29,13 @@ public class ClipTreeNodeViewModel : INotifyPropertyChanged
     public bool IsFolder => Clip is null;
     public bool IsClip => Clip is not null;
 
+    /// <summary>
+    /// Folder segments leading from the repository root to this node. For
+    /// folder nodes this includes the folder's own name; for clip leaves it
+    /// matches the clip's <see cref="ClipViewModel.FolderPath"/>.
+    /// </summary>
+    public IReadOnlyList<string> Path { get; private set; } = [];
+
     public ObservableCollection<ClipTreeNodeViewModel> Children { get; } = [];
 
     private bool _isExpanded = true;
@@ -43,8 +51,15 @@ public class ClipTreeNodeViewModel : INotifyPropertyChanged
         Clip = clip;
     }
 
-    public static ClipTreeNodeViewModel Folder(string name) => new(name, null);
-    public static ClipTreeNodeViewModel ClipLeaf(ClipViewModel clip) => new(clip.Clip.Name, clip);
+    public static ClipTreeNodeViewModel Folder(string name, IReadOnlyList<string> path)
+    {
+        return new ClipTreeNodeViewModel(name, null) { Path = path };
+    }
+
+    public static ClipTreeNodeViewModel ClipLeaf(ClipViewModel clip)
+    {
+        return new ClipTreeNodeViewModel(clip.Clip.Name, clip) { Path = clip.FolderPath };
+    }
 
     /// <summary>
     /// Build a set of root-level nodes from a flat clip collection. Clips are
@@ -53,17 +68,28 @@ public class ClipTreeNodeViewModel : INotifyPropertyChanged
     /// are sorted by name for stable display.
     /// </summary>
     /// <param name="clips">Flat clip collection.</param>
+    /// <param name="folders">Materialized folders (including empty ones) the
+    /// tree should render even when they contain no clips.</param>
     /// <param name="searchText">Optional filter. When non-empty, only clips
     /// whose names contain the text survive (case-insensitive); folders survive
     /// when they have any surviving descendant, and matching folders are
-    /// auto-expanded.</param>
+    /// auto-expanded. Empty folders are filtered out while a filter is active.</param>
     public static IReadOnlyList<ClipTreeNodeViewModel> Build(
         IEnumerable<ClipViewModel> clips,
-        string searchText = "")
+        string searchText = "",
+        IEnumerable<FolderData>? folders = null)
     {
         var rootFolders = new Dictionary<string, ClipTreeNodeViewModel>(StringComparer.OrdinalIgnoreCase);
         var rootLeaves = new List<ClipTreeNodeViewModel>();
         var filter = string.IsNullOrEmpty(searchText) ? null : searchText;
+
+        if (filter is null && folders is not null)
+        {
+            foreach (var folder in folders)
+            {
+                EnsureFolderPath(rootFolders, folder);
+            }
+        }
 
         foreach (var clip in clips)
         {
@@ -75,7 +101,7 @@ public class ClipTreeNodeViewModel : INotifyPropertyChanged
                 var head = clip.FolderPath[0];
                 if (!rootFolders.TryGetValue(head, out var folder))
                 {
-                    folder = Folder(head);
+                    folder = Folder(head, new[] { head });
                     rootFolders.Add(head, folder);
                 }
 
@@ -87,9 +113,10 @@ public class ClipTreeNodeViewModel : INotifyPropertyChanged
             }
         }
 
-        // Drop folders that end up empty after filtering.
+        // Filtering hides empty folders; with no filter, materialized folders
+        // (created or pasted) stay visible even before they contain anything.
         var folderList = rootFolders.Values
-            .Where(f => HasAnyDescendant(f))
+            .Where(f => filter is null || HasAnyDescendant(f))
             .OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
@@ -101,6 +128,38 @@ public class ClipTreeNodeViewModel : INotifyPropertyChanged
         result.AddRange(folderList);
         result.AddRange(rootLeaves);
         return result;
+    }
+
+    private static void EnsureFolderPath(
+        Dictionary<string, ClipTreeNodeViewModel> rootFolders,
+        FolderData folder)
+    {
+        if (folder.Path.Count == 0) return;
+
+        var head = folder.Path[0];
+        if (!rootFolders.TryGetValue(head, out var node))
+        {
+            node = Folder(head, new[] { head });
+            rootFolders.Add(head, node);
+        }
+        EnsureFolderChildren(node, folder.Path, depth: 1);
+    }
+
+    private static void EnsureFolderChildren(
+        ClipTreeNodeViewModel parent,
+        IReadOnlyList<string> path,
+        int depth)
+    {
+        if (depth >= path.Count) return;
+        var segment = path[depth];
+        var child = parent.Children.FirstOrDefault(c => c.IsFolder &&
+            string.Equals(c.Name, segment, StringComparison.OrdinalIgnoreCase));
+        if (child is null)
+        {
+            child = Folder(segment, path.Take(depth + 1).ToArray());
+            parent.Children.Add(child);
+        }
+        EnsureFolderChildren(child, path, depth + 1);
     }
 
     private static void InsertClipIntoFolder(
@@ -123,7 +182,7 @@ public class ClipTreeNodeViewModel : INotifyPropertyChanged
             string.Equals(c.Name, segment, StringComparison.OrdinalIgnoreCase));
         if (child is null)
         {
-            child = Folder(segment);
+            child = Folder(segment, path.Take(depth + 1).ToArray());
             folder.Children.Add(child);
         }
 

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -758,8 +758,27 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
     private void RebuildTree()
     {
         var nodes = ClipTreeNodeViewModel.Build(FileMakerClips, _searchText, Folders);
+        var root = ClipTreeNodeViewModel.Folder(RootNodeLabel, []);
+        foreach (var n in nodes) root.Children.Add(n);
         RootNodes.Clear();
-        foreach (var n in nodes) RootNodes.Add(n);
+        RootNodes.Add(root);
+    }
+
+    /// <summary>
+    /// Label for the synthetic root node shown at the top of the tree. Derived
+    /// from the current repository location's leaf segment so it adapts when
+    /// the user switches folders; falls back to a generic label for repos
+    /// whose location string isn't a filesystem path.
+    /// </summary>
+    private string RootNodeLabel
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(_currentPath)) return "All Clips";
+            var trimmed = _currentPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var leaf = Path.GetFileName(trimmed);
+            return string.IsNullOrEmpty(leaf) ? "All Clips" : leaf;
+        }
     }
 
     private string _currentPath;
@@ -770,6 +789,7 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         {
             _currentPath = value;
             NotifyPropertyChanged();
+            RebuildTree();
         }
     }
 

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -123,6 +123,9 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
 
         RootNodes = [];
 
+        Folders = [];
+        Folders.CollectionChanged += (_, _) => RebuildTree();
+
         FileMakerClips = [];
         FileMakerClips.CollectionChanged += (sender, e) =>
         {
@@ -145,24 +148,26 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         };
 
         _repository = new ClipRepository(_currentPath);
-        LoadClipsFromRepository();
+        LoadFromRepository();
     }
 
     public IClipRepository ActiveRepository => _repository;
 
-    private void LoadClipsFromRepository()
+    private void LoadFromRepository()
     {
         var clips = _repository.LoadClipsAsync().GetAwaiter().GetResult();
-        PopulateClips(clips);
+        var folders = _repository.LoadFoldersAsync().GetAwaiter().GetResult();
+        Populate(clips, folders);
     }
 
-    private async Task LoadClipsFromRepositoryAsync()
+    private async Task LoadFromRepositoryAsync()
     {
         var clips = await _repository.LoadClipsAsync();
-        PopulateClips(clips);
+        var folders = await _repository.LoadFoldersAsync();
+        Populate(clips, folders);
     }
 
-    private void PopulateClips(IReadOnlyList<ClipData> clips)
+    private void Populate(IReadOnlyList<ClipData> clips, IReadOnlyList<FolderData> folders)
     {
         // Closing the tab strip first keeps the editor area from holding refs
         // to clips that are about to be replaced.
@@ -173,6 +178,10 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         // the outgoing clips explicitly.
         foreach (var c in FileMakerClips) c.Dispose();
         FileMakerClips.Clear();
+        Folders.Clear();
+
+        foreach (var folder in folders) Folders.Add(folder);
+
         foreach (var clip in clips)
         {
             FileMakerClips.Add(new ClipViewModel(
@@ -189,7 +198,7 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         {
             CurrentPath = await _folderService.GetFolderAsync();
             _repository = new ClipRepository(CurrentPath);
-            await LoadClipsFromRepositoryAsync();
+            await LoadFromRepositoryAsync();
             ShowStatus($"Opened {CurrentPath}");
         }
         catch (Exception e)
@@ -203,7 +212,7 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
     {
         _repository = repository;
         CurrentPath = repository.CurrentLocation;
-        await LoadClipsFromRepositoryAsync();
+        await LoadFromRepositoryAsync();
         ShowStatus($"Switched to {repository.ProviderName}: {repository.CurrentLocation}");
     }
 
@@ -221,6 +230,9 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
                 })
                 .ToList();
 
+            // Folders persist first so the orphan sweep in SaveClipsAsync
+            // sees up-to-date marker files when reclaiming empty directories.
+            await _repository.SaveFoldersAsync(Folders.ToList());
             await _repository.SaveClipsAsync(clipData);
 
             foreach (var c in FileMakerClips) c.MarkSaved();
@@ -291,12 +303,47 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
 
     public void NewTableCommand() => CreateNewClip("New Table", "Mac-XMTB", "table");
 
+    /// <summary>
+    /// Create an empty folder under the current target folder. The user is
+    /// prompted for the folder name; cancelling or supplying a blank/colliding
+    /// name aborts.
+    /// </summary>
+    public async Task NewFolderCommand()
+    {
+        var parent = TargetFolderPath;
+
+        var entered = await _prompt.PromptAsync("New folder", "Folder name:", "New Folder");
+        if (entered is null) return;
+
+        var trimmed = entered.Trim();
+        if (trimmed.Length == 0)
+        {
+            ShowStatus("Folder name cannot be empty", isError: true);
+            return;
+        }
+
+        var path = Combine(parent, new[] { trimmed });
+        if (Folders.Any(f => FolderPathsEqual(f.Path, path)))
+        {
+            ShowStatus($"Folder '{trimmed}' already exists at this level", isError: true);
+            return;
+        }
+
+        Folders.Add(new FolderData(path));
+        SelectedFolderPath = path;
+        ShowStatus($"Created folder '{trimmed}'");
+    }
+
     private void CreateNewClip(string name, string format, string kind)
     {
         try
         {
+            var folderPath = TargetFolderPath;
             var seed = ClipTypeRegistry.For(format).DefaultXml(name);
-            var vm = new ClipViewModel(Clip.FromXml(name, format, seed));
+            var vm = new ClipViewModel(Clip.FromXml(name, format, seed))
+            {
+                FolderPath = folderPath,
+            };
             FileMakerClips.Add(vm);
             SelectedClip = vm;
             ShowStatus($"Created new {kind}");
@@ -368,9 +415,10 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
             int count = 0;
             ClipViewModel? lastAdded = null;
 
-            // Group pastes land relative to the currently selected clip's folder
-            // so the user can drop a folder into the spot they're looking at.
-            var pasteRoot = SelectedClip?.FolderPath ?? [];
+            // Group pastes land relative to the current target folder so the
+            // user can drop a folder into the spot they're looking at — whether
+            // that's a selected clip's folder or an explicitly tapped empty one.
+            var pasteRoot = TargetFolderPath;
 
             foreach (var format in formats.Where(f => f.StartsWith("Mac-", StringComparison.CurrentCultureIgnoreCase)).Distinct())
             {
@@ -382,10 +430,16 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
 
                 var rawClip = Clip.FromWireBytes("new-clip", format, dataObj);
 
-                var groupEntries = GroupPasteDecomposer.TryDecompose(rawClip.Xml);
-                if (groupEntries is { Count: > 0 })
+                var decomposed = GroupPasteDecomposer.TryDecompose(rawClip.Xml);
+                if (decomposed is { Entries.Count: > 0 })
                 {
-                    foreach (var entry in groupEntries)
+                    foreach (var folder in decomposed.Folders)
+                    {
+                        var fullPath = Combine(pasteRoot, folder.Path);
+                        UpsertFolder(folder with { Path = fullPath });
+                    }
+
+                    foreach (var entry in decomposed.Entries)
                     {
                         var entryClip = Clip.FromXml("new-clip", format, entry.Xml);
                         if (FileMakerClips.Any(k => k.Clip.Xml == entryClip.Xml &&
@@ -567,6 +621,27 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
     public ObservableCollection<ClipViewModel> FileMakerClips { get; set; }
 
     /// <summary>
+    /// Folder metadata for every materialized folder — empty folders the user
+    /// created locally and the FileMaker <c>&lt;Group&gt;</c> attributes captured
+    /// when a Group paste landed. The tree builder consults this collection so
+    /// empty folders still render.
+    /// </summary>
+    public ObservableCollection<FolderData> Folders { get; }
+
+    private void UpsertFolder(FolderData folder)
+    {
+        for (var i = 0; i < Folders.Count; i++)
+        {
+            if (FolderPathsEqual(Folders[i].Path, folder.Path))
+            {
+                Folders[i] = folder;
+                return;
+            }
+        }
+        Folders.Add(folder);
+    }
+
+    /// <summary>
     /// VS Code-style open tabs — the right-side editor area binds to this.
     /// </summary>
     public OpenTabsViewModel OpenTabs { get; }
@@ -589,9 +664,47 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         {
             StatusMessage = "";
             if (value is null) { OpenTabs.ActiveTab = null; NotifyPropertyChanged(); return; }
+            SelectedFolderPath = null;
             OpenTabs.OpenAsPermanent(value);
             NotifyPropertyChanged();
         }
+    }
+
+    private IReadOnlyList<string>? _selectedFolderPath;
+
+    /// <summary>
+    /// Folder path tapped in the tree, if any. New clip/folder/paste operations
+    /// land relative to this path (it takes priority over the selected clip's
+    /// own folder). Cleared when a clip is opened.
+    /// </summary>
+    public IReadOnlyList<string>? SelectedFolderPath
+    {
+        get => _selectedFolderPath;
+        set
+        {
+            _selectedFolderPath = value;
+            NotifyPropertyChanged();
+            NotifyPropertyChanged(nameof(TargetFolderPath));
+        }
+    }
+
+    /// <summary>
+    /// Where the next "new" or "paste" operation will land. Resolves to the
+    /// explicitly tapped folder, else the selected clip's folder, else root.
+    /// </summary>
+    public IReadOnlyList<string> TargetFolderPath =>
+        SelectedFolderPath ?? SelectedClip?.FolderPath ?? [];
+
+    /// <summary>
+    /// Select a folder node in the tree as the active target for new clip /
+    /// paste / new folder operations. Closes any open clip preview so the
+    /// selection is unambiguous.
+    /// </summary>
+    public void OpenFolderAsSelection(IReadOnlyList<string> folderPath)
+    {
+        OpenTabs.ActiveTab = null;
+        SelectedFolderPath = folderPath;
+        NotifyPropertyChanged(nameof(SelectedClip));
     }
 
     /// <summary>True when the status bar should display a parse-fidelity summary for the selected clip.</summary>
@@ -644,7 +757,7 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
 
     private void RebuildTree()
     {
-        var nodes = ClipTreeNodeViewModel.Build(FileMakerClips, _searchText);
+        var nodes = ClipTreeNodeViewModel.Build(FileMakerClips, _searchText, Folders);
         RootNodes.Clear();
         foreach (var n in nodes) RootNodes.Add(n);
     }

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -334,17 +334,30 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
-    // Pick a clip name that doesn't collide with anything already loaded.
-    // Returns the input when it's free, otherwise appends "(2)", "(3)", … until
-    // a free slot is found.
-    private string UniqueClipName(string desired)
+    // Pick a clip name that doesn't collide with anything already loaded in
+    // the same folder. Folder paths are compared case-insensitively, matching
+    // the tree's grouping rules.
+    private string UniqueClipName(string desired, IReadOnlyList<string> folderPath)
     {
-        if (FileMakerClips.All(c => c.Clip.Name != desired)) return desired;
+        bool Collides(string candidate) => FileMakerClips.Any(c =>
+            c.Clip.Name == candidate && FolderPathsEqual(c.FolderPath, folderPath));
+
+        if (!Collides(desired)) return desired;
         for (var n = 2; ; n++)
         {
             var candidate = $"{desired} ({n})";
-            if (FileMakerClips.All(c => c.Clip.Name != candidate)) return candidate;
+            if (!Collides(candidate)) return candidate;
         }
+    }
+
+    private static bool FolderPathsEqual(IReadOnlyList<string> a, IReadOnlyList<string> b)
+    {
+        if (a.Count != b.Count) return false;
+        for (var i = 0; i < a.Count; i++)
+        {
+            if (!string.Equals(a[i], b[i], StringComparison.OrdinalIgnoreCase)) return false;
+        }
+        return true;
     }
 
     public async Task PasteFileMakerClipData()
@@ -355,6 +368,10 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
             int count = 0;
             ClipViewModel? lastAdded = null;
 
+            // Group pastes land relative to the currently selected clip's folder
+            // so the user can drop a folder into the spot they're looking at.
+            var pasteRoot = SelectedClip?.FolderPath ?? [];
+
             foreach (var format in formats.Where(f => f.StartsWith("Mac-", StringComparison.CurrentCultureIgnoreCase)).Distinct())
             {
                 if (string.IsNullOrEmpty(format)) continue;
@@ -363,16 +380,36 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
 
                 if (clipData is not byte[] dataObj) continue;
 
-                var clip = Clip.FromWireBytes("new-clip", format, dataObj);
+                var rawClip = Clip.FromWireBytes("new-clip", format, dataObj);
+
+                var groupEntries = GroupPasteDecomposer.TryDecompose(rawClip.Xml);
+                if (groupEntries is { Count: > 0 })
+                {
+                    foreach (var entry in groupEntries)
+                    {
+                        var entryClip = Clip.FromXml("new-clip", format, entry.Xml);
+                        if (FileMakerClips.Any(k => k.Clip.Xml == entryClip.Xml &&
+                            FolderPathsEqual(k.FolderPath, Combine(pasteRoot, entry.FolderPath))))
+                            continue;
+
+                        var folderPath = Combine(pasteRoot, entry.FolderPath);
+                        entryClip = entryClip.Rename(UniqueClipName(entry.Name, folderPath));
+
+                        lastAdded = new ClipViewModel(entryClip) { FolderPath = folderPath };
+                        FileMakerClips.Add(lastAdded);
+                        count++;
+                    }
+                    continue;
+                }
 
                 // don't add duplicates
-                if (FileMakerClips.Any(k => k.Clip.Xml == clip.Xml)) continue;
+                if (FileMakerClips.Any(k => k.Clip.Xml == rawClip.Xml)) continue;
 
-                var sourceName = ClipTypeRegistry.For(format).TryGetSourceName(clip.Xml);
+                var sourceName = ClipTypeRegistry.For(format).TryGetSourceName(rawClip.Xml);
                 var desired = string.IsNullOrWhiteSpace(sourceName) ? "new-clip" : sourceName;
-                clip = clip.Rename(UniqueClipName(desired));
+                var singleClip = rawClip.Rename(UniqueClipName(desired, pasteRoot));
 
-                lastAdded = new ClipViewModel(clip);
+                lastAdded = new ClipViewModel(singleClip) { FolderPath = pasteRoot };
                 FileMakerClips.Add(lastAdded);
                 count++;
             }
@@ -389,6 +426,16 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
             _logger.LogError(e, "Error pasting from FileMaker clipboard.");
             ShowStatus("Error pasting from clipboard", isError: true);
         }
+    }
+
+    private static IReadOnlyList<string> Combine(IReadOnlyList<string> root, IReadOnlyList<string> sub)
+    {
+        if (root.Count == 0) return sub;
+        if (sub.Count == 0) return root;
+        var combined = new string[root.Count + sub.Count];
+        for (var i = 0; i < root.Count; i++) combined[i] = root[i];
+        for (var i = 0; i < sub.Count; i++) combined[root.Count + i] = sub[i];
+        return combined;
     }
 
     public async Task CopySelectedToClip()

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -299,7 +299,9 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         ShowStatus($"Deleted clip '{name}'");
     }
 
-    public void NewScriptCommand() => CreateNewClip("New Script", "Mac-XMSS", "script");
+    public void NewScriptCommand() => CreateNewClip("New Script", "Mac-XMSC", "script");
+
+    public void NewScriptStepsCommand() => CreateNewClip("New Script Steps", "Mac-XMSS", "script steps");
 
     public void NewTableCommand() => CreateNewClip("New Table", "Mac-XMTB", "table");
 
@@ -330,7 +332,6 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         }
 
         Folders.Add(new FolderData(path));
-        SelectedFolderPath = path;
         ShowStatus($"Created folder '{trimmed}'");
     }
 
@@ -696,15 +697,14 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
         SelectedFolderPath ?? SelectedClip?.FolderPath ?? [];
 
     /// <summary>
-    /// Select a folder node in the tree as the active target for new clip /
-    /// paste / new folder operations. Closes any open clip preview so the
-    /// selection is unambiguous.
+    /// Select a folder path as the active target for new clip / paste /
+    /// new folder operations. An empty path means "the repository root".
+    /// The tab strip is intentionally left alone — navigating the tree should
+    /// not close whatever the user is editing.
     /// </summary>
     public void OpenFolderAsSelection(IReadOnlyList<string> folderPath)
     {
-        OpenTabs.ActiveTab = null;
         SelectedFolderPath = folderPath;
-        NotifyPropertyChanged(nameof(SelectedClip));
     }
 
     /// <summary>True when the status bar should display a parse-fidelity summary for the selected clip.</summary>

--- a/tests/SharpFM.Plugin.Tests/PluginHostTests.cs
+++ b/tests/SharpFM.Plugin.Tests/PluginHostTests.cs
@@ -49,7 +49,7 @@ public class PluginHostTests
 
         Assert.NotNull(host.SelectedClip);
         Assert.Equal("New Script", host.SelectedClip!.Name);
-        Assert.Equal("Mac-XMSS", host.SelectedClip.ClipType);
+        Assert.Equal("Mac-XMSC", host.SelectedClip.ClipType);
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public class PluginHostTests
 
         Assert.NotNull(clip);
         Assert.Equal("New Script", clip!.Name);
-        Assert.Equal("Mac-XMSS", clip.ClipType);
+        Assert.Equal("Mac-XMSC", clip.ClipType);
     }
 
     [Fact]

--- a/tests/SharpFM.Tests/Models/ClipRepositoryTests.cs
+++ b/tests/SharpFM.Tests/Models/ClipRepositoryTests.cs
@@ -393,6 +393,92 @@ public class ClipRepositoryTests
     }
 
     [Fact]
+    public async Task ClipName_WithSlash_RoundTrips()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            await repo.SaveClipsAsync([new("Go-To-Record/Request/Page", "Mac-XMSC", "<x/>")]);
+
+            var loaded = await repo.LoadClipsAsync();
+
+            var clip = Assert.Single(loaded);
+            Assert.Equal("Go-To-Record/Request/Page", clip.Name);
+            Assert.Empty(clip.FolderPath);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task ClipName_WithMultipleInvalidChars_RoundTrips()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            var weirdName = "a/b\\c:d*e?f\"g<h>i|j";
+            await repo.SaveClipsAsync([new(weirdName, "Mac-XMSS", "<x/>")]);
+
+            var loaded = await repo.LoadClipsAsync();
+            Assert.Equal(weirdName, Assert.Single(loaded).Name);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task ClipName_LiteralPercent_RoundTrips()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            await repo.SaveClipsAsync([new("100% done", "Mac-XMSS", "<x/>")]);
+
+            var loaded = await repo.LoadClipsAsync();
+            Assert.Equal("100% done", Assert.Single(loaded).Name);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task FolderSegment_WithSlash_RoundTrips()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            await repo.SaveClipsAsync([new("Inside", "Mac-XMSC", "<x/>")
+                { FolderPath = new[] { "Date/Time", "Helpers" } }]);
+
+            var loaded = await repo.LoadClipsAsync();
+            var clip = Assert.Single(loaded);
+            Assert.Equal(new[] { "Date/Time", "Helpers" }, clip.FolderPath);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task FolderMetadata_WithSlashInSegment_RoundTrips()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            await repo.SaveFoldersAsync([
+                new(new[] { "Date/Time" }) { Id = 7, IncludeInMenu = false }
+            ]);
+
+            var loaded = await repo.LoadFoldersAsync();
+            var folder = Assert.Single(loaded);
+            Assert.Equal(new[] { "Date/Time" }, folder.Path);
+            Assert.Equal(7, folder.Id);
+            Assert.False(folder.IncludeInMenu);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
     public async Task SaveClipsAsync_RejectsTraversalSegments()
     {
         var dir = CreateTempDir();

--- a/tests/SharpFM.Tests/Models/ClipRepositoryTests.cs
+++ b/tests/SharpFM.Tests/Models/ClipRepositoryTests.cs
@@ -241,6 +241,158 @@ public class ClipRepositoryTests
     }
 
     [Fact]
+    public async Task SaveFoldersAsync_WritesMarkerWithMetadata()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            var folders = new List<FolderData>
+            {
+                new(new[] { "Group A" }) { Id = 42, IncludeInMenu = false, GroupCollapsed = true }
+            };
+
+            await repo.SaveFoldersAsync(folders);
+
+            var marker = Path.Combine(dir, "Group A", ".sharpfm-folder.json");
+            Assert.True(File.Exists(marker));
+            var contents = File.ReadAllText(marker);
+            Assert.Contains("\"id\": 42", contents);
+            Assert.Contains("\"includeInMenu\": false", contents);
+            Assert.Contains("\"groupCollapsed\": true", contents);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task LoadFoldersAsync_ReadsMarkerMetadata()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var sub = Path.Combine(dir, "Group A");
+            Directory.CreateDirectory(sub);
+            File.WriteAllText(Path.Combine(sub, ".sharpfm-folder.json"),
+                "{\"id\": 7, \"includeInMenu\": false, \"groupCollapsed\": true}");
+
+            var repo = new ClipRepository(dir);
+            var folders = await repo.LoadFoldersAsync();
+
+            var f = Assert.Single(folders);
+            Assert.Equal(new[] { "Group A" }, f.Path);
+            Assert.Equal(7, f.Id);
+            Assert.False(f.IncludeInMenu);
+            Assert.True(f.GroupCollapsed);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveFoldersAsync_EmptyFolder_CreatesDirectory()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            await repo.SaveFoldersAsync([new(new[] { "Empty" })]);
+
+            Assert.True(Directory.Exists(Path.Combine(dir, "Empty")));
+            Assert.True(File.Exists(Path.Combine(dir, "Empty", ".sharpfm-folder.json")));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task LoadClipsAsync_IgnoresFolderMarkerFile()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var sub = Path.Combine(dir, "Group");
+            Directory.CreateDirectory(sub);
+            File.WriteAllText(Path.Combine(sub, ".sharpfm-folder.json"), "{}");
+            File.WriteAllText(Path.Combine(sub, "Real.Mac-XMSS"), "<x/>");
+
+            var repo = new ClipRepository(dir);
+            var clips = await repo.LoadClipsAsync();
+
+            var clip = Assert.Single(clips);
+            Assert.Equal("Real", clip.Name);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveClipsAsync_KeepsEmptyFolderWithMarker()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var sub = Path.Combine(dir, "KeepMe");
+            Directory.CreateDirectory(sub);
+            File.WriteAllText(Path.Combine(sub, ".sharpfm-folder.json"), "{}");
+
+            var repo = new ClipRepository(dir);
+            await repo.SaveClipsAsync([new("Root", "Mac-XMSS", "<r/>")]);
+
+            Assert.True(Directory.Exists(sub));
+            Assert.True(File.Exists(Path.Combine(sub, ".sharpfm-folder.json")));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveFoldersAsync_DeletesOrphanedMarkers()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var a = Path.Combine(dir, "A");
+            var b = Path.Combine(dir, "B");
+            Directory.CreateDirectory(a);
+            Directory.CreateDirectory(b);
+            File.WriteAllText(Path.Combine(a, ".sharpfm-folder.json"), "{}");
+            File.WriteAllText(Path.Combine(b, ".sharpfm-folder.json"), "{}");
+
+            var repo = new ClipRepository(dir);
+            await repo.SaveFoldersAsync([new(new[] { "A" })]);
+
+            Assert.True(File.Exists(Path.Combine(a, ".sharpfm-folder.json")));
+            Assert.False(File.Exists(Path.Combine(b, ".sharpfm-folder.json")));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task FolderRoundtrip_PreservesMetadata()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            await repo.SaveFoldersAsync([
+                new(new[] { "Outer", "Inner" }) { Id = 99, IncludeInMenu = false, GroupCollapsed = true },
+                new(new[] { "Outer" }) { Id = 1 }
+            ]);
+
+            var loaded = await repo.LoadFoldersAsync();
+
+            Assert.Equal(2, loaded.Count);
+            var inner = loaded.Single(f => f.Path.Count == 2);
+            Assert.Equal(new[] { "Outer", "Inner" }, inner.Path);
+            Assert.Equal(99, inner.Id);
+            Assert.False(inner.IncludeInMenu);
+            Assert.True(inner.GroupCollapsed);
+
+            var outer = loaded.Single(f => f.Path.Count == 1);
+            Assert.Equal(1, outer.Id);
+            Assert.True(outer.IncludeInMenu);
+            Assert.False(outer.GroupCollapsed);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
     public async Task SaveClipsAsync_RejectsTraversalSegments()
     {
         var dir = CreateTempDir();

--- a/tests/SharpFM.Tests/Models/GroupPasteDecomposerTests.cs
+++ b/tests/SharpFM.Tests/Models/GroupPasteDecomposerTests.cs
@@ -1,0 +1,131 @@
+using System.Linq;
+using System.Xml.Linq;
+using SharpFM.Model;
+using Xunit;
+
+namespace SharpFM.Tests.Models;
+
+public class GroupPasteDecomposerTests
+{
+    [Fact]
+    public void NoGroups_ReturnsNull()
+    {
+        var xml = "<fmxmlsnippet type=\"FMObjectList\"><Script name=\"Solo\" id=\"1\"/></fmxmlsnippet>";
+        Assert.Null(GroupPasteDecomposer.TryDecompose(xml));
+    }
+
+    [Fact]
+    public void SingleGroupWithOneScript_EmitsOneEntryUnderFolder()
+    {
+        var xml = """
+            <fmxmlsnippet type="FMObjectList">
+              <Group groupCollapsed="False" includeInMenu="False" id="16" name="Paste Targets">
+                <Script includeInMenu="False" runFullAccess="False" id="19" name="FizzBuzz">
+                  <Step enable="True" id="141" name="Set Variable"/>
+                </Script>
+              </Group>
+            </fmxmlsnippet>
+            """;
+
+        var entries = GroupPasteDecomposer.TryDecompose(xml);
+
+        Assert.NotNull(entries);
+        var entry = Assert.Single(entries!);
+        Assert.Equal("FizzBuzz", entry.Name);
+        Assert.Equal(new[] { "Paste Targets" }, entry.FolderPath);
+
+        var doc = XDocument.Parse(entry.Xml);
+        Assert.Equal("fmxmlsnippet", doc.Root!.Name.LocalName);
+        var script = doc.Root.Element("Script")!;
+        Assert.Equal("FizzBuzz", script.Attribute("name")!.Value);
+        Assert.Equal("19", script.Attribute("id")!.Value);
+        Assert.Null(doc.Root.Element("Group"));
+    }
+
+    [Fact]
+    public void MultipleScriptsInGroup_EmitsOneEntryPerScript()
+    {
+        var xml = """
+            <fmxmlsnippet type="FMObjectList">
+              <Group id="1" name="Utilities">
+                <Script id="10" name="Alpha"/>
+                <Script id="11" name="Beta"/>
+                <Script id="12" name="Gamma"/>
+              </Group>
+            </fmxmlsnippet>
+            """;
+
+        var entries = GroupPasteDecomposer.TryDecompose(xml);
+
+        Assert.NotNull(entries);
+        Assert.Equal(3, entries!.Count);
+        Assert.All(entries, e => Assert.Equal(new[] { "Utilities" }, e.FolderPath));
+        Assert.Equal(new[] { "Alpha", "Beta", "Gamma" }, entries.Select(e => e.Name));
+    }
+
+    [Fact]
+    public void NestedGroups_ProduceNestedFolders()
+    {
+        var xml = """
+            <fmxmlsnippet type="FMObjectList">
+              <Group id="1" name="Outer">
+                <Script id="10" name="OuterScript"/>
+                <Group id="2" name="Inner">
+                  <Script id="20" name="InnerScript"/>
+                </Group>
+              </Group>
+            </fmxmlsnippet>
+            """;
+
+        var entries = GroupPasteDecomposer.TryDecompose(xml);
+
+        Assert.NotNull(entries);
+        Assert.Equal(2, entries!.Count);
+        var outer = entries.Single(e => e.Name == "OuterScript");
+        Assert.Equal(new[] { "Outer" }, outer.FolderPath);
+        var inner = entries.Single(e => e.Name == "InnerScript");
+        Assert.Equal(new[] { "Outer", "Inner" }, inner.FolderPath);
+    }
+
+    [Fact]
+    public void LooseScriptAlongsideGroup_StaysAtRoot()
+    {
+        var xml = """
+            <fmxmlsnippet type="FMObjectList">
+              <Script id="5" name="Loose"/>
+              <Group id="1" name="Folder">
+                <Script id="10" name="Inside"/>
+              </Group>
+            </fmxmlsnippet>
+            """;
+
+        var entries = GroupPasteDecomposer.TryDecompose(xml);
+
+        Assert.NotNull(entries);
+        Assert.Equal(2, entries!.Count);
+        var loose = entries.Single(e => e.Name == "Loose");
+        Assert.Empty(loose.FolderPath);
+        var inside = entries.Single(e => e.Name == "Inside");
+        Assert.Equal(new[] { "Folder" }, inside.FolderPath);
+    }
+
+    [Fact]
+    public void EachEntryXml_WrapsScriptInFmxmlsnippet()
+    {
+        var xml = """
+            <fmxmlsnippet type="FMObjectList">
+              <Group id="1" name="G">
+                <Script id="10" name="S">
+                  <Step enable="True" id="141" name="Set Variable"><Name>$i</Name></Step>
+                </Script>
+              </Group>
+            </fmxmlsnippet>
+            """;
+
+        var entries = GroupPasteDecomposer.TryDecompose(xml)!;
+        var entry = Assert.Single(entries);
+        var doc = XDocument.Parse(entry.Xml);
+        Assert.Equal("FMObjectList", doc.Root!.Attribute("type")?.Value);
+        Assert.NotNull(doc.Root.Element("Script")!.Element("Step"));
+    }
+}

--- a/tests/SharpFM.Tests/Models/GroupPasteDecomposerTests.cs
+++ b/tests/SharpFM.Tests/Models/GroupPasteDecomposerTests.cs
@@ -27,10 +27,10 @@ public class GroupPasteDecomposerTests
             </fmxmlsnippet>
             """;
 
-        var entries = GroupPasteDecomposer.TryDecompose(xml);
+        var result = GroupPasteDecomposer.TryDecompose(xml);
 
-        Assert.NotNull(entries);
-        var entry = Assert.Single(entries!);
+        Assert.NotNull(result);
+        var entry = Assert.Single(result!.Entries);
         Assert.Equal("FizzBuzz", entry.Name);
         Assert.Equal(new[] { "Paste Targets" }, entry.FolderPath);
 
@@ -55,12 +55,12 @@ public class GroupPasteDecomposerTests
             </fmxmlsnippet>
             """;
 
-        var entries = GroupPasteDecomposer.TryDecompose(xml);
+        var result = GroupPasteDecomposer.TryDecompose(xml);
 
-        Assert.NotNull(entries);
-        Assert.Equal(3, entries!.Count);
-        Assert.All(entries, e => Assert.Equal(new[] { "Utilities" }, e.FolderPath));
-        Assert.Equal(new[] { "Alpha", "Beta", "Gamma" }, entries.Select(e => e.Name));
+        Assert.NotNull(result);
+        Assert.Equal(3, result!.Entries.Count);
+        Assert.All(result.Entries, e => Assert.Equal(new[] { "Utilities" }, e.FolderPath));
+        Assert.Equal(new[] { "Alpha", "Beta", "Gamma" }, result.Entries.Select(e => e.Name));
     }
 
     [Fact]
@@ -77,13 +77,13 @@ public class GroupPasteDecomposerTests
             </fmxmlsnippet>
             """;
 
-        var entries = GroupPasteDecomposer.TryDecompose(xml);
+        var result = GroupPasteDecomposer.TryDecompose(xml);
 
-        Assert.NotNull(entries);
-        Assert.Equal(2, entries!.Count);
-        var outer = entries.Single(e => e.Name == "OuterScript");
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.Entries.Count);
+        var outer = result.Entries.Single(e => e.Name == "OuterScript");
         Assert.Equal(new[] { "Outer" }, outer.FolderPath);
-        var inner = entries.Single(e => e.Name == "InnerScript");
+        var inner = result.Entries.Single(e => e.Name == "InnerScript");
         Assert.Equal(new[] { "Outer", "Inner" }, inner.FolderPath);
     }
 
@@ -99,14 +99,82 @@ public class GroupPasteDecomposerTests
             </fmxmlsnippet>
             """;
 
-        var entries = GroupPasteDecomposer.TryDecompose(xml);
+        var result = GroupPasteDecomposer.TryDecompose(xml);
 
-        Assert.NotNull(entries);
-        Assert.Equal(2, entries!.Count);
-        var loose = entries.Single(e => e.Name == "Loose");
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.Entries.Count);
+        var loose = result.Entries.Single(e => e.Name == "Loose");
         Assert.Empty(loose.FolderPath);
-        var inside = entries.Single(e => e.Name == "Inside");
+        var inside = result.Entries.Single(e => e.Name == "Inside");
         Assert.Equal(new[] { "Folder" }, inside.FolderPath);
+    }
+
+    [Fact]
+    public void Decompose_CapturesGroupAttributes()
+    {
+        var xml = """
+            <fmxmlsnippet type="FMObjectList">
+              <Group groupCollapsed="True" includeInMenu="False" id="16" name="Paste Targets">
+                <Script id="19" name="FizzBuzz"/>
+              </Group>
+            </fmxmlsnippet>
+            """;
+
+        var result = GroupPasteDecomposer.TryDecompose(xml);
+
+        Assert.NotNull(result);
+        var folder = Assert.Single(result!.Folders);
+        Assert.Equal(new[] { "Paste Targets" }, folder.Path);
+        Assert.Equal(16, folder.Id);
+        Assert.False(folder.IncludeInMenu);
+        Assert.True(folder.GroupCollapsed);
+    }
+
+    [Fact]
+    public void Decompose_NestedGroups_EmitsFolderPerLevel()
+    {
+        var xml = """
+            <fmxmlsnippet type="FMObjectList">
+              <Group id="1" name="Outer" includeInMenu="True" groupCollapsed="False">
+                <Group id="2" name="Inner" includeInMenu="False" groupCollapsed="True">
+                  <Script id="20" name="InnerScript"/>
+                </Group>
+              </Group>
+            </fmxmlsnippet>
+            """;
+
+        var result = GroupPasteDecomposer.TryDecompose(xml)!;
+
+        Assert.Equal(2, result.Folders.Count);
+        var outer = result.Folders.Single(f => f.Path.Count == 1);
+        Assert.Equal("Outer", outer.Path[0]);
+        Assert.Equal(1, outer.Id);
+        Assert.True(outer.IncludeInMenu);
+        Assert.False(outer.GroupCollapsed);
+
+        var inner = result.Folders.Single(f => f.Path.Count == 2);
+        Assert.Equal(new[] { "Outer", "Inner" }, inner.Path);
+        Assert.Equal(2, inner.Id);
+        Assert.False(inner.IncludeInMenu);
+        Assert.True(inner.GroupCollapsed);
+    }
+
+    [Fact]
+    public void Decompose_DefaultGroupAttributes_AreSensible()
+    {
+        var xml = """
+            <fmxmlsnippet type="FMObjectList">
+              <Group id="9" name="Bare">
+                <Script id="10" name="X"/>
+              </Group>
+            </fmxmlsnippet>
+            """;
+
+        var result = GroupPasteDecomposer.TryDecompose(xml)!;
+        var folder = Assert.Single(result.Folders);
+        Assert.Equal(9, folder.Id);
+        Assert.True(folder.IncludeInMenu);
+        Assert.False(folder.GroupCollapsed);
     }
 
     [Fact]
@@ -122,8 +190,8 @@ public class GroupPasteDecomposerTests
             </fmxmlsnippet>
             """;
 
-        var entries = GroupPasteDecomposer.TryDecompose(xml)!;
-        var entry = Assert.Single(entries);
+        var result = GroupPasteDecomposer.TryDecompose(xml)!;
+        var entry = Assert.Single(result.Entries);
         var doc = XDocument.Parse(entry.Xml);
         Assert.Equal("FMObjectList", doc.Root!.Attribute("type")?.Value);
         Assert.NotNull(doc.Root.Element("Script")!.Element("Step"));

--- a/tests/SharpFM.Tests/ViewModels/ClipTreeNodeViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/ClipTreeNodeViewModelTests.cs
@@ -81,6 +81,70 @@ public class ClipTreeNodeViewModelTests
     }
 
     [Fact]
+    public void Build_EmptyFolder_RendersAsFolderNode()
+    {
+        var folders = new[] { new FolderData(new[] { "Empty" }) };
+
+        var nodes = ClipTreeNodeViewModel.Build([], folders: folders);
+
+        var empty = Assert.Single(nodes);
+        Assert.True(empty.IsFolder);
+        Assert.Equal("Empty", empty.Name);
+        Assert.Equal(new[] { "Empty" }, empty.Path);
+        Assert.Empty(empty.Children);
+    }
+
+    [Fact]
+    public void Build_NestedFolderNode_CarriesFullPath()
+    {
+        var folders = new[] { new FolderData(new[] { "Outer", "Inner" }) };
+
+        var nodes = ClipTreeNodeViewModel.Build([], folders: folders);
+
+        var outer = Assert.Single(nodes);
+        Assert.Equal(new[] { "Outer" }, outer.Path);
+        var inner = outer.Children.Single();
+        Assert.Equal(new[] { "Outer", "Inner" }, inner.Path);
+    }
+
+    [Fact]
+    public void Build_ClipDerivedFolder_CarriesPath()
+    {
+        var clips = new[] { Clip("X", "Outer", "Inner") };
+
+        var nodes = ClipTreeNodeViewModel.Build(clips);
+
+        var outer = Assert.Single(nodes);
+        Assert.Equal(new[] { "Outer" }, outer.Path);
+        var inner = outer.Children.Single(c => c.IsFolder);
+        Assert.Equal(new[] { "Outer", "Inner" }, inner.Path);
+    }
+
+    [Fact]
+    public void Build_EmptyFolderInsideClipFolder_RendersAsChild()
+    {
+        var clips = new[] { Clip("Sibling", "Scripts") };
+        var folders = new[] { new FolderData(new[] { "Scripts", "Drafts" }) };
+
+        var nodes = ClipTreeNodeViewModel.Build(clips, folders: folders);
+
+        var scripts = Assert.Single(nodes);
+        var drafts = scripts.Children.Single(c => c.IsFolder);
+        Assert.Equal("Drafts", drafts.Name);
+        Assert.Empty(drafts.Children);
+    }
+
+    [Fact]
+    public void Build_FilterActive_HidesEmptyFolders()
+    {
+        var folders = new[] { new FolderData(new[] { "Empty" }) };
+
+        var nodes = ClipTreeNodeViewModel.Build([], "needle", folders);
+
+        Assert.Empty(nodes);
+    }
+
+    [Fact]
     public void Build_IsStable_WhenFolderPathCasingDiffers()
     {
         var clips = new[]

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -278,6 +278,110 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public async Task PasteFileMakerClipData_GroupWithSingleScript_CreatesClipUnderFolder()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSC"] = BuildClipBytes(
+            "<fmxmlsnippet type=\"FMObjectList\"><Group id=\"16\" name=\"Paste Targets\">" +
+            "<Script id=\"19\" name=\"FizzBuzz\"><Step enable=\"True\" id=\"141\" name=\"Set Variable\"/></Script>" +
+            "</Group></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        vm.FileMakerClips.Clear();
+
+        await vm.PasteFileMakerClipData();
+
+        var pasted = Assert.Single(vm.FileMakerClips);
+        Assert.Equal("FizzBuzz", pasted.Clip.Name);
+        Assert.Equal(new[] { "Paste Targets" }, pasted.FolderPath);
+    }
+
+    [Fact]
+    public async Task PasteFileMakerClipData_GroupWithMultipleScripts_CreatesAllUnderSameFolder()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSC"] = BuildClipBytes(
+            "<fmxmlsnippet type=\"FMObjectList\"><Group id=\"1\" name=\"Utils\">" +
+            "<Script id=\"10\" name=\"A\"/><Script id=\"11\" name=\"B\"/><Script id=\"12\" name=\"C\"/>" +
+            "</Group></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        vm.FileMakerClips.Clear();
+
+        await vm.PasteFileMakerClipData();
+
+        Assert.Equal(3, vm.FileMakerClips.Count);
+        Assert.All(vm.FileMakerClips, c => Assert.Equal(new[] { "Utils" }, c.FolderPath));
+        Assert.Equal(new[] { "A", "B", "C" }, vm.FileMakerClips.Select(c => c.Clip.Name).OrderBy(n => n));
+    }
+
+    [Fact]
+    public async Task PasteFileMakerClipData_NestedGroups_ProduceNestedFolders()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSC"] = BuildClipBytes(
+            "<fmxmlsnippet type=\"FMObjectList\"><Group id=\"1\" name=\"Outer\">" +
+            "<Script id=\"10\" name=\"Top\"/>" +
+            "<Group id=\"2\" name=\"Inner\"><Script id=\"20\" name=\"Deep\"/></Group>" +
+            "</Group></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        vm.FileMakerClips.Clear();
+
+        await vm.PasteFileMakerClipData();
+
+        Assert.Equal(2, vm.FileMakerClips.Count);
+        var top = vm.FileMakerClips.Single(c => c.Clip.Name == "Top");
+        Assert.Equal(new[] { "Outer" }, top.FolderPath);
+        var deep = vm.FileMakerClips.Single(c => c.Clip.Name == "Deep");
+        Assert.Equal(new[] { "Outer", "Inner" }, deep.FolderPath);
+    }
+
+    [Fact]
+    public async Task PasteFileMakerClipData_GroupCollisionWithExistingFolder_MergesIntoIt()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSC"] = BuildClipBytes(
+            "<fmxmlsnippet type=\"FMObjectList\"><Group id=\"1\" name=\"Shared\">" +
+            "<Script id=\"10\" name=\"NewOne\"/></Group></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        vm.FileMakerClips.Clear();
+        var existing = new ClipViewModel(Clip.FromXml("Existing", "Mac-XMSC", "<fmxmlsnippet/>"))
+        {
+            FolderPath = new[] { "Shared" },
+        };
+        vm.FileMakerClips.Add(existing);
+
+        await vm.PasteFileMakerClipData();
+
+        Assert.Equal(2, vm.FileMakerClips.Count);
+        var pasted = vm.FileMakerClips.Single(c => c.Clip.Name == "NewOne");
+        Assert.Equal(new[] { "Shared" }, pasted.FolderPath);
+    }
+
+    [Fact]
+    public async Task PasteFileMakerClipData_GroupPaste_StartsAtSelectedClipsFolder()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSC"] = BuildClipBytes(
+            "<fmxmlsnippet type=\"FMObjectList\"><Script id=\"5\" name=\"Loose\"/>" +
+            "<Group id=\"1\" name=\"Sub\"><Script id=\"10\" name=\"Inside\"/></Group>" +
+            "</fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        vm.FileMakerClips.Clear();
+        var anchor = new ClipViewModel(Clip.FromXml("Anchor", "Mac-XMSC", "<fmxmlsnippet/>"))
+        {
+            FolderPath = new[] { "Parent" },
+        };
+        vm.FileMakerClips.Add(anchor);
+        vm.SelectedClip = anchor;
+
+        await vm.PasteFileMakerClipData();
+
+        var loose = vm.FileMakerClips.Single(c => c.Clip.Name == "Loose");
+        Assert.Equal(new[] { "Parent" }, loose.FolderPath);
+        var inside = vm.FileMakerClips.Single(c => c.Clip.Name == "Inside");
+        Assert.Equal(new[] { "Parent", "Sub" }, inside.FolderPath);
+    }
+
+    [Fact]
     public void StatusMessage_NotifiesPropertyChanged()
     {
         var vm = CreateVm();

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -80,7 +80,17 @@ public class MainWindowViewModelTests
         vm.NewScriptCommand();
         Assert.Equal(initialCount + 1, vm.FileMakerClips.Count);
         Assert.True(vm.SelectedClip?.IsScriptClip);
+        Assert.Equal("Mac-XMSC", vm.SelectedClip!.ClipType);
         Assert.Contains("Created new script", vm.StatusMessage);
+    }
+
+    [Fact]
+    public void NewScriptStepsCommand_AddsBareStepsClip()
+    {
+        var vm = CreateVm();
+        vm.NewScriptStepsCommand();
+        Assert.True(vm.SelectedClip?.IsScriptClip);
+        Assert.Equal("Mac-XMSS", vm.SelectedClip!.ClipType);
     }
 
     [Fact]
@@ -213,6 +223,19 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public async Task NewFolderCommand_TwiceAtRoot_ProducesSiblings()
+    {
+        var vm = CreateVm(prompt: new FakeInputPrompt("A", "B"));
+        ResetRepoState(vm);
+
+        await vm.NewFolderCommand();
+        await vm.NewFolderCommand();
+
+        Assert.Equal(2, vm.Folders.Count);
+        Assert.All(vm.Folders, f => Assert.Single(f.Path));
+    }
+
+    [Fact]
     public void NewScriptCommand_LandsInSelectedFolder()
     {
         var vm = CreateVm();
@@ -266,6 +289,34 @@ public class MainWindowViewModelTests
         Assert.Null(vm.SelectedFolderPath);
     }
 
+    [Fact]
+    public void OpenFolderAsSelection_KeepsActiveTab()
+    {
+        var vm = CreateVm();
+        ResetRepoState(vm);
+        vm.NewScriptCommand();
+        var openClip = vm.SelectedClip;
+        Assert.NotNull(openClip);
+
+        vm.OpenFolderAsSelection(new[] { "Schemas" });
+
+        Assert.Same(openClip, vm.SelectedClip);
+        Assert.Equal(new[] { "Schemas" }, vm.TargetFolderPath);
+    }
+
+    [Fact]
+    public void TargetFolderPath_PrefersExplicitFolderOverSelectedClipFolder()
+    {
+        var vm = CreateVm();
+        ResetRepoState(vm);
+        vm.NewScriptCommand();
+        vm.SelectedClip!.FolderPath = new[] { "Original" };
+
+        vm.OpenFolderAsSelection(new[] { "Override" });
+
+        Assert.Equal(new[] { "Override" }, vm.TargetFolderPath);
+    }
+
 
     [Fact]
     public async Task NewFolderCommand_CancelledPrompt_AddsNothing()
@@ -297,9 +348,6 @@ public class MainWindowViewModelTests
         ResetRepoState(vm);
         await vm.NewFolderCommand();
         Assert.Single(vm.Folders);
-        // Successful create selects the new folder; clear so the second call
-        // targets the same root level and trips the duplicate check.
-        vm.SelectedFolderPath = null;
 
         await vm.NewFolderCommand();
 

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -191,7 +191,7 @@ public class MainWindowViewModelTests
 
         var folder = Assert.Single(vm.Folders);
         Assert.Equal(new[] { "Drafts" }, folder.Path);
-        Assert.Contains(vm.RootNodes, n => n.IsFolder && n.Name == "Drafts");
+        Assert.Contains(TopLevel(vm), n => n.IsFolder && n.Name == "Drafts");
         Assert.Contains("Created folder", vm.StatusMessage);
     }
 
@@ -302,6 +302,34 @@ public class MainWindowViewModelTests
 
         Assert.Same(openClip, vm.SelectedClip);
         Assert.Equal(new[] { "Schemas" }, vm.TargetFolderPath);
+    }
+
+    [Fact]
+    public void RootNodes_AlwaysContainsSyntheticRoot_WithPathEmpty()
+    {
+        var vm = CreateVm();
+        ResetRepoState(vm);
+
+        var root = Assert.Single(vm.RootNodes);
+        Assert.True(root.IsFolder);
+        Assert.Empty(root.Path);
+        Assert.Empty(root.Children);
+    }
+
+    [Fact]
+    public void RootNodes_RootWraps_AllTopLevelItems()
+    {
+        var vm = CreateVm();
+        ResetRepoState(vm);
+        // Root-level clip
+        vm.NewScriptCommand();
+        // Folder under root
+        vm.OpenFolderAsSelection(new[] { "Foo" });
+        vm.NewScriptCommand();
+
+        var root = Assert.Single(vm.RootNodes);
+        Assert.Contains(root.Children, c => c.IsFolder && c.Name == "Foo");
+        Assert.Contains(root.Children, c => c.IsClip && c.Name == "New Script");
     }
 
     [Fact]
@@ -647,12 +675,12 @@ public class MainWindowViewModelTests
         vm.NewScriptCommand();
         var clip = vm.SelectedClip!;
         Assert.Contains(clip, vm.FileMakerClips);
-        Assert.Contains(vm.RootNodes, n => n.IsClip && ReferenceEquals(n.Clip, clip));
+        Assert.Contains(TopLevel(vm), n => n.IsClip && ReferenceEquals(n.Clip, clip));
 
         vm.DeleteSelectedClip();
 
         Assert.DoesNotContain(clip, vm.FileMakerClips);
-        Assert.DoesNotContain(vm.RootNodes, n => n.IsClip && ReferenceEquals(n.Clip, clip));
+        Assert.DoesNotContain(TopLevel(vm), n => n.IsClip && ReferenceEquals(n.Clip, clip));
     }
 
     [Fact]
@@ -661,10 +689,18 @@ public class MainWindowViewModelTests
         var vm = CreateVm();
         vm.NewScriptCommand(); // adds a clip named "New Script"
         vm.SearchText = "zzz_nonexistent";
-        Assert.Empty(vm.RootNodes);
+        Assert.Empty(TopLevel(vm));
         vm.SearchText = "";
-        Assert.NotEmpty(vm.RootNodes);
+        Assert.NotEmpty(TopLevel(vm));
     }
+
+    /// <summary>
+    /// Children of the synthetic root node. RebuildTree always wraps the
+    /// repository's top level in a single root so tests written against
+    /// "directly in the tree" use this helper.
+    /// </summary>
+    private static System.Collections.ObjectModel.ObservableCollection<ClipTreeNodeViewModel> TopLevel(MainWindowViewModel vm) =>
+        Assert.Single(vm.RootNodes).Children;
 
     [Fact]
     public void AllPlugins_DefaultsToEmpty()

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -51,8 +51,13 @@ public class MainWindowViewModelTests
             prompt);
     }
 
-    private sealed class FakeInputPrompt(string? answer) : IInputPrompt
+    private sealed class FakeInputPrompt(params string?[]? answers) : IInputPrompt
     {
+        // A single explicit `null` argument resolves to `params` = null rather
+        // than a one-element array; treat both the same as "always cancel".
+        private readonly Queue<string?> _answers = new(
+            answers ?? new string?[] { null });
+
         public string? LastTitle { get; private set; }
         public string? LastPrompt { get; private set; }
         public string? LastDefault { get; private set; }
@@ -62,6 +67,7 @@ public class MainWindowViewModelTests
             LastTitle = title;
             LastPrompt = prompt;
             LastDefault = defaultValue;
+            var answer = _answers.Count > 0 ? _answers.Dequeue() : null;
             return Task.FromResult(answer);
         }
     }
@@ -163,6 +169,152 @@ public class MainWindowViewModelTests
         await vm.RenameSelectedClip();
 
         Assert.Equal(original, vm.SelectedClip!.Clip.Name);
+    }
+
+    [Fact]
+    public async Task NewFolderCommand_PromptsAndAddsEmptyFolderAtRoot()
+    {
+        var vm = CreateVm(prompt: new FakeInputPrompt("Drafts"));
+        ResetRepoState(vm);
+
+        await vm.NewFolderCommand();
+
+        var folder = Assert.Single(vm.Folders);
+        Assert.Equal(new[] { "Drafts" }, folder.Path);
+        Assert.Contains(vm.RootNodes, n => n.IsFolder && n.Name == "Drafts");
+        Assert.Contains("Created folder", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task NewFolderCommand_RelativeToSelectedClipFolder()
+    {
+        var vm = CreateVm(prompt: new FakeInputPrompt("Sub"));
+        ResetRepoState(vm);
+        vm.NewScriptCommand();
+        vm.SelectedClip!.FolderPath = new[] { "Top" };
+
+        await vm.NewFolderCommand();
+
+        var folder = vm.Folders.Single(f => f.Path.Count == 2);
+        Assert.Equal(new[] { "Top", "Sub" }, folder.Path);
+    }
+
+    [Fact]
+    public async Task NewFolderCommand_NestsInsideSelectedFolder()
+    {
+        var vm = CreateVm(prompt: new FakeInputPrompt("Outer", "Inner"));
+        ResetRepoState(vm);
+        await vm.NewFolderCommand();
+        vm.OpenFolderAsSelection(new[] { "Outer" });
+        await vm.NewFolderCommand();
+
+        Assert.Contains(vm.Folders, f =>
+            f.Path.Count == 2 && f.Path[0] == "Outer" && f.Path[1] == "Inner");
+    }
+
+    [Fact]
+    public void NewScriptCommand_LandsInSelectedFolder()
+    {
+        var vm = CreateVm();
+        ResetRepoState(vm);
+        vm.OpenFolderAsSelection(new[] { "Drafts" });
+
+        vm.NewScriptCommand();
+
+        var script = Assert.Single(vm.FileMakerClips);
+        Assert.Equal(new[] { "Drafts" }, script.FolderPath);
+    }
+
+    [Fact]
+    public void NewTableCommand_LandsInSelectedFolder()
+    {
+        var vm = CreateVm();
+        ResetRepoState(vm);
+        vm.OpenFolderAsSelection(new[] { "Schemas" });
+
+        vm.NewTableCommand();
+
+        var table = Assert.Single(vm.FileMakerClips);
+        Assert.Equal(new[] { "Schemas" }, table.FolderPath);
+    }
+
+    [Fact]
+    public async Task PasteFileMakerClipData_LandsInSelectedFolder()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSS"] = BuildClipBytes(
+            "<fmxmlsnippet type=\"FMObjectList\"><Script id=\"5\" name=\"X\"/></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        ResetRepoState(vm);
+        vm.OpenFolderAsSelection(new[] { "Drop Here" });
+
+        await vm.PasteFileMakerClipData();
+
+        var pasted = Assert.Single(vm.FileMakerClips);
+        Assert.Equal(new[] { "Drop Here" }, pasted.FolderPath);
+    }
+
+    [Fact]
+    public void SelectedFolderPath_ClearsWhenClipSelected()
+    {
+        var vm = CreateVm();
+        vm.OpenFolderAsSelection(new[] { "Folder" });
+        Assert.NotNull(vm.SelectedFolderPath);
+
+        vm.NewScriptCommand();
+
+        Assert.Null(vm.SelectedFolderPath);
+    }
+
+
+    [Fact]
+    public async Task NewFolderCommand_CancelledPrompt_AddsNothing()
+    {
+        var vm = CreateVm(prompt: new FakeInputPrompt(null));
+        ResetRepoState(vm);
+
+        await vm.NewFolderCommand();
+
+        Assert.Empty(vm.Folders);
+    }
+
+    [Fact]
+    public async Task NewFolderCommand_BlankName_ShowsError()
+    {
+        var vm = CreateVm(prompt: new FakeInputPrompt("   "));
+        ResetRepoState(vm);
+
+        await vm.NewFolderCommand();
+
+        Assert.Empty(vm.Folders);
+        Assert.Contains("cannot be empty", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task NewFolderCommand_DuplicateName_ShowsError()
+    {
+        var vm = CreateVm(prompt: new FakeInputPrompt("Dup", "Dup"));
+        ResetRepoState(vm);
+        await vm.NewFolderCommand();
+        Assert.Single(vm.Folders);
+        // Successful create selects the new folder; clear so the second call
+        // targets the same root level and trips the duplicate check.
+        vm.SelectedFolderPath = null;
+
+        await vm.NewFolderCommand();
+
+        Assert.Single(vm.Folders);
+        Assert.Contains("already exists", vm.StatusMessage);
+    }
+
+    // Tests that assert exact catalog sizes need to start from a clean slate.
+    // CreateVm constructs a MainWindowViewModel that eagerly loads from the
+    // default LocalApplicationData repo path, so anything left there by prior
+    // user sessions or earlier tests would leak in otherwise.
+    private static void ResetRepoState(MainWindowViewModel vm)
+    {
+        vm.FileMakerClips.Clear();
+        vm.Folders.Clear();
     }
 
     [Fact]
@@ -278,6 +430,26 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public async Task PasteFileMakerClipData_GroupPaste_CapturesFolderMetadata()
+    {
+        var clipboard = new MockClipboardService();
+        clipboard.ClipboardData["Mac-XMSC"] = BuildClipBytes(
+            "<fmxmlsnippet type=\"FMObjectList\">" +
+            "<Group groupCollapsed=\"True\" includeInMenu=\"False\" id=\"16\" name=\"Paste Targets\">" +
+            "<Script id=\"19\" name=\"FizzBuzz\"/></Group></fmxmlsnippet>");
+        var vm = CreateVm(clipboard);
+        ResetRepoState(vm);
+
+        await vm.PasteFileMakerClipData();
+
+        var folder = Assert.Single(vm.Folders);
+        Assert.Equal(new[] { "Paste Targets" }, folder.Path);
+        Assert.Equal(16, folder.Id);
+        Assert.False(folder.IncludeInMenu);
+        Assert.True(folder.GroupCollapsed);
+    }
+
+    [Fact]
     public async Task PasteFileMakerClipData_GroupWithSingleScript_CreatesClipUnderFolder()
     {
         var clipboard = new MockClipboardService();
@@ -365,7 +537,7 @@ public class MainWindowViewModelTests
             "<Group id=\"1\" name=\"Sub\"><Script id=\"10\" name=\"Inside\"/></Group>" +
             "</fmxmlsnippet>");
         var vm = CreateVm(clipboard);
-        vm.FileMakerClips.Clear();
+        ResetRepoState(vm);
         var anchor = new ClipViewModel(Clip.FromXml("Anchor", "Mac-XMSC", "<fmxmlsnippet/>"))
         {
             FolderPath = new[] { "Parent" },
@@ -379,6 +551,9 @@ public class MainWindowViewModelTests
         Assert.Equal(new[] { "Parent" }, loose.FolderPath);
         var inside = vm.FileMakerClips.Single(c => c.Clip.Name == "Inside");
         Assert.Equal(new[] { "Parent", "Sub" }, inside.FolderPath);
+
+        var folder = Assert.Single(vm.Folders);
+        Assert.Equal(new[] { "Parent", "Sub" }, folder.Path);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Pasting a script `Group` from FileMaker decomposes into one clip per `<Script>`, mirroring the Group hierarchy as folders in the clip repository. Single-clip paste behavior is unchanged.

- `GroupPasteDecomposer` walks `fmxmlsnippet`, emitting one entry per `<Script>` plus a `FolderData` per `<Group>` carrying `id`, `includeInMenu`, and `groupCollapsed`. Returns null when the snippet has no Group so the existing single-clip path is preserved.
- `MainWindowViewModel.PasteFileMakerClipData` branches on the decomposer's result and lands group pastes relative to the currently selected clip/folder, so the paste appears where the user was looking. Loose scripts alongside a Group share the paste root; nested Groups produce nested folders.
- Name uniqueness is scoped per-folder, so two clips with the same name in different folders are allowed; collisions suffix `(2)`, `(3)`, …
- Folder-name collisions merge into the existing folder.

## Folder persistence

- New `FolderData` model carries Group metadata; `IClipRepository` gains default-implemented `LoadFoldersAsync` / `SaveFoldersAsync`.
- `ClipRepository` persists folders as `.sharpfm-folder.json` sidecars; empty folders survive saves and load as standalone tree nodes.
- New Folder command added (File menu + tree context menu); the tree tracks folder selection so new clips, folders, and pastes land in the targeted folder.
- Invalid filename characters are percent-encoded on disk for both clip names and folder segments.

## Tree UX

- Tree pre-expands by default and rebinds `TreeViewItem.IsExpanded` so expansion state survives rebuilds.
- Explicit root node added; clip panel fills available height.
- File menu splits "New Script" (Mac-XMSC) vs "New Script Steps" (Mac-XMSS).

## Tests

Coverage spans the decomposer (single Group, multiple scripts, nested Groups, loose scripts, attribute capture), the paste handler (group + collision + paste-at-selected-hierarchy), folder persistence + percent-encoding round-trips, and tree-selection behavior. Full suite: 1306 + 101 passing.

Closes #206