### PR TITLE
fix: report dropped segments when sanitizing folder paths

### DIFF
--- a/src/SharpFM/Models/ClipRepository.cs
+++ b/src/SharpFM/Models/ClipRepository.cs
@@ -234,19 +234,41 @@ public class ClipRepository : IClipRepository
         return decoded;
     }
 
-    // Reject traversal segments (security) and percent-encode any character
-    // the filesystem rejects so FileMaker names containing '/' or ':' survive
-    // the round-trip instead of being silently dropped.
-    private static IReadOnlyList<string> SanitizeFolderPath(IReadOnlyList<string> segments)
+    /// <summary>
+    /// Raised when <see cref="SanitizeFolderPath"/> drops one or more segments
+    /// (empty, whitespace, or traversal). Hosts can subscribe to surface a
+    /// non-blocking notification so plugin-driven placements that landed
+    /// somewhere other than requested are visible to the user.
+    /// </summary>
+    public event EventHandler<FolderPathSanitizedEventArgs>? FolderPathSanitized;
+
+    // Empty / "." / ".." segments are dropped (not encoded) — the call is
+    // best-effort, not a hard error, but the dropped segments are reported via
+    // Log.Warn and FolderPathSanitized so the caller can surface them.
+    private IReadOnlyList<string> SanitizeFolderPath(IReadOnlyList<string> segments)
     {
         if (segments is null || segments.Count == 0) return [];
         var safe = new List<string>(segments.Count);
+        var dropped = new List<string>();
         foreach (var raw in segments)
         {
-            if (string.IsNullOrWhiteSpace(raw)) continue;
-            if (raw == "." || raw == "..") continue;
+            if (string.IsNullOrWhiteSpace(raw) || raw == "." || raw == "..")
+            {
+                dropped.Add(raw ?? "");
+                continue;
+            }
             safe.Add(EncodeName(raw));
         }
+
+        if (dropped.Count > 0)
+        {
+            Log.Warn(
+                "Sanitized folder path: dropped [{Dropped}]; kept [{Kept}].",
+                string.Join(", ", dropped),
+                string.Join("/", safe));
+            FolderPathSanitized?.Invoke(this, new FolderPathSanitizedEventArgs(segments, safe, dropped));
+        }
+
         return safe;
     }
 

--- a/src/SharpFM/Models/FolderPathSanitizedEventArgs.cs
+++ b/src/SharpFM/Models/FolderPathSanitizedEventArgs.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace SharpFM.Models;
+
+/// <summary>
+/// Payload for <see cref="ClipRepository.FolderPathSanitized"/>. Reports the
+/// original folder path, the path that was actually used, and the segments
+/// that were dropped during sanitization.
+/// </summary>
+public sealed class FolderPathSanitizedEventArgs : EventArgs
+{
+    public IReadOnlyList<string> Original { get; }
+    public IReadOnlyList<string> Sanitized { get; }
+    public IReadOnlyList<string> DroppedSegments { get; }
+
+    public FolderPathSanitizedEventArgs(
+        IReadOnlyList<string> original,
+        IReadOnlyList<string> sanitized,
+        IReadOnlyList<string> droppedSegments)
+    {
+        Original = original;
+        Sanitized = sanitized;
+        DroppedSegments = droppedSegments;
+    }
+}

--- a/src/SharpFM/ViewModels/MainWindowViewModel.cs
+++ b/src/SharpFM/ViewModels/MainWindowViewModel.cs
@@ -230,14 +230,32 @@ public partial class MainWindowViewModel : INotifyPropertyChanged
                 })
                 .ToList();
 
-            // Folders persist first so the orphan sweep in SaveClipsAsync
-            // sees up-to-date marker files when reclaiming empty directories.
-            await _repository.SaveFoldersAsync(Folders.ToList());
-            await _repository.SaveClipsAsync(clipData);
+            var sanitized = 0;
+            void OnSanitized(object? _, FolderPathSanitizedEventArgs __) => sanitized++;
+            var fileRepo = _repository as ClipRepository;
+            if (fileRepo is not null) fileRepo.FolderPathSanitized += OnSanitized;
+
+            try
+            {
+                // Folders persist first so the orphan sweep in SaveClipsAsync
+                // sees up-to-date marker files when reclaiming empty directories.
+                await _repository.SaveFoldersAsync(Folders.ToList());
+                await _repository.SaveClipsAsync(clipData);
+            }
+            finally
+            {
+                if (fileRepo is not null) fileRepo.FolderPathSanitized -= OnSanitized;
+            }
 
             foreach (var c in FileMakerClips) c.MarkSaved();
 
-            ShowStatus($"Saved {clipData.Count} clip(s) to {_repository.CurrentLocation}");
+            var hadSanitization = sanitized > 0;
+            var suffix = hadSanitization
+                ? $"; sanitized {sanitized} folder path(s) — see log for dropped segments"
+                : "";
+            ShowStatus(
+                $"Saved {clipData.Count} clip(s) to {_repository.CurrentLocation}{suffix}",
+                isError: hadSanitization);
         }
         catch (Exception e)
         {

--- a/tests/SharpFM.Tests/Models/ClipRepositoryTests.cs
+++ b/tests/SharpFM.Tests/Models/ClipRepositoryTests.cs
@@ -502,4 +502,99 @@ public class ClipRepositoryTests
             if (Directory.Exists(sibling)) Directory.Delete(sibling, true);
         }
     }
+
+    [Fact]
+    public async Task SaveClipsAsync_TraversalSegment_RaisesFolderPathSanitizedEvent()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            FolderPathSanitizedEventArgs? captured = null;
+            repo.FolderPathSanitized += (_, e) => captured = e;
+
+            await repo.SaveClipsAsync([new("X", "Mac-XMSS", "<x/>")
+                { FolderPath = new[] { "..", "Real" } }]);
+
+            Assert.NotNull(captured);
+            Assert.Equal(new[] { "..", "Real" }, captured!.Original);
+            Assert.Equal(new[] { "Real" }, captured.Sanitized);
+            Assert.Equal(new[] { ".." }, captured.DroppedSegments);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveClipsAsync_EmptySegment_RaisesEventNamingDropped()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            FolderPathSanitizedEventArgs? captured = null;
+            repo.FolderPathSanitized += (_, e) => captured = e;
+
+            await repo.SaveClipsAsync([new("X", "Mac-XMSS", "<x/>")
+                { FolderPath = new[] { "Real", "   " } }]);
+
+            Assert.NotNull(captured);
+            Assert.Equal(new[] { "Real" }, captured!.Sanitized);
+            Assert.Single(captured.DroppedSegments);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveClipsAsync_AllValidSegments_DoesNotRaiseEvent()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            var fired = 0;
+            repo.FolderPathSanitized += (_, _) => fired++;
+
+            await repo.SaveClipsAsync([new("X", "Mac-XMSS", "<x/>")
+                { FolderPath = new[] { "Group", "Sub" } }]);
+
+            Assert.Equal(0, fired);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveClipsAsync_PercentEncodedOnly_DoesNotRaiseEvent()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            var fired = 0;
+            repo.FolderPathSanitized += (_, _) => fired++;
+
+            await repo.SaveClipsAsync([new("X", "Mac-XMSS", "<x/>")
+                { FolderPath = new[] { "Date/Time" } }]);
+
+            Assert.Equal(0, fired);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SaveFoldersAsync_TraversalSegment_RaisesFolderPathSanitizedEvent()
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            var repo = new ClipRepository(dir);
+            FolderPathSanitizedEventArgs? captured = null;
+            repo.FolderPathSanitized += (_, e) => captured = e;
+
+            await repo.SaveFoldersAsync([new(new[] { "..", "Real" })]);
+
+            Assert.NotNull(captured);
+            Assert.Equal(new[] { ".." }, captured!.DroppedSegments);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
 }

--- a/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/tests/SharpFM.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -422,6 +422,34 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public async Task SaveClips_SanitizationDropsSegment_StatusIncludesSanitizedSuffix()
+    {
+        var vm = CreateVm();
+        ResetRepoState(vm);
+        var clip = Clip.FromXml("Test", "Mac-XMSC", "<x/>");
+        vm.FileMakerClips.Add(new ClipViewModel(clip) { FolderPath = new[] { "..", "Real" } });
+
+        await vm.SaveClipsStorageAsync();
+
+        Assert.Contains("Saved", vm.StatusMessage);
+        Assert.Contains("sanitized 1 folder path", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task SaveClips_NoSanitization_StatusOmitsSuffix()
+    {
+        var vm = CreateVm();
+        ResetRepoState(vm);
+        var clip = Clip.FromXml("Test", "Mac-XMSC", "<x/>");
+        vm.FileMakerClips.Add(new ClipViewModel(clip));
+
+        await vm.SaveClipsStorageAsync();
+
+        Assert.Contains("Saved", vm.StatusMessage);
+        Assert.DoesNotContain("sanitized", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task PasteFileMakerClipData_NoFormats_ShowsStatus()
     {
         var clipboard = new MockClipboardService();


### PR DESCRIPTION
## Summary

- `ClipRepository.SanitizeFolderPath` now logs `Log.Warn` naming the dropped segments and what was kept whenever it discards `.`/`..`/whitespace segments.
- New `FolderPathSanitized` event on `ClipRepository` carries the original path, the sanitized path, and the dropped segments.
- `MainWindowViewModel.SaveClipsStorageAsync` subscribes around the save and appends `; sanitized N folder path(s) — see log for dropped segments` to the final status when sanitization fired, so plugin-driven or user-typed placements that landed somewhere unexpected are visible.
- Percent-encoded segments (e.g. `Date/Time`) do not trigger the warning — that's a reversible round-trip, not a drop.