### PR TITLE
refactor: build clip XML via XElement instead of string interpolation

### DIFF
--- a/src/SharpFM.Model/ClipTypes/IClipTypeStrategy.cs
+++ b/src/SharpFM.Model/ClipTypes/IClipTypeStrategy.cs
@@ -26,7 +26,9 @@ public interface IClipTypeStrategy
 
     /// <summary>
     /// Produce a starter XML body for a fresh clip with the given name. Used by
-    /// "new clip" flows in the host and by plugins.
+    /// "new clip" flows in the host and by plugins. Build with
+    /// <see cref="System.Xml.Linq.XElement"/> rather than string concatenation so
+    /// XML metacharacters in <paramref name="clipName"/> are escaped by the framework.
     /// </summary>
     string DefaultXml(string clipName);
 

--- a/src/SharpFM.Model/ClipTypes/TableClipStrategy.cs
+++ b/src/SharpFM.Model/ClipTypes/TableClipStrategy.cs
@@ -5,7 +5,6 @@ using System.Xml;
 using System.Xml.Linq;
 using SharpFM.Model.Parsing;
 using SharpFM.Model.Schema;
-using SharpFM.Model.Scripting;
 
 namespace SharpFM.Model.ClipTypes;
 
@@ -65,10 +64,15 @@ public sealed class TableClipStrategy : IClipTypeStrategy
         return new ParseSuccess(new TableClipModel(table), report);
     }
 
-    public string DefaultXml(string clipName) =>
-        _wrapsBaseTable
-            ? $"<fmxmlsnippet type=\"FMObjectList\"><BaseTable name=\"{XmlHelpers.XmlEscape(clipName)}\"></BaseTable></fmxmlsnippet>"
-            : "<fmxmlsnippet type=\"FMObjectList\"></fmxmlsnippet>";
+    public string DefaultXml(string clipName)
+    {
+        var snippet = new XElement("fmxmlsnippet", new XAttribute("type", "FMObjectList"));
+        if (_wrapsBaseTable)
+        {
+            snippet.Add(new XElement("BaseTable", new XAttribute("name", clipName)));
+        }
+        return snippet.ToString(SaveOptions.DisableFormatting);
+    }
 
     public string? TryGetSourceName(string xml)
     {

--- a/src/SharpFM.Model/Schema/FmField.cs
+++ b/src/SharpFM.Model/Schema/FmField.cs
@@ -189,7 +189,7 @@ public class FmField : INotifyPropertyChanged
         // Calculation
         if (!string.IsNullOrEmpty(Calculation))
         {
-            var calcEl = XElement.Parse($"<Calculation><![CDATA[{Calculation}]]></Calculation>");
+            var calcEl = new XElement("Calculation", new XCData(Calculation));
             if (AlwaysEvaluate)
                 calcEl.Add(new XAttribute("alwaysEvaluate", "True"));
             if (!string.IsNullOrEmpty(CalculationContext))
@@ -222,10 +222,10 @@ public class FmField : INotifyPropertyChanged
                         new XAttribute("nextSerialNumber", AutoEnterValue ?? "1")));
                     break;
                 case AutoEnterType.ConstantData:
-                    autoEl.Add(XElement.Parse($"<ConstantData><![CDATA[{AutoEnterValue ?? ""}]]></ConstantData>"));
+                    autoEl.Add(new XElement("ConstantData", new XCData(AutoEnterValue ?? "")));
                     break;
                 case AutoEnterType.Calculation:
-                    autoEl.Add(XElement.Parse($"<Calculation><![CDATA[{AutoEnterValue ?? ""}]]></Calculation>"));
+                    autoEl.Add(new XElement("Calculation", new XCData(AutoEnterValue ?? "")));
                     break;
             }
 
@@ -249,16 +249,16 @@ public class FmField : INotifyPropertyChanged
             {
                 var rangeEl = new XElement("Range");
                 if (RangeMin != null)
-                    rangeEl.Add(XElement.Parse($"<MinimumValue><![CDATA[{RangeMin}]]></MinimumValue>"));
+                    rangeEl.Add(new XElement("MinimumValue", new XCData(RangeMin)));
                 if (RangeMax != null)
-                    rangeEl.Add(XElement.Parse($"<MaximumValue><![CDATA[{RangeMax}]]></MaximumValue>"));
+                    rangeEl.Add(new XElement("MaximumValue", new XCData(RangeMax)));
                 valEl.Add(rangeEl);
             }
 
             if (ValidationCalculation != null)
-                valEl.Add(XElement.Parse($"<StrictValidation><![CDATA[{ValidationCalculation}]]></StrictValidation>"));
+                valEl.Add(new XElement("StrictValidation", new XCData(ValidationCalculation)));
             if (ErrorMessage != null)
-                valEl.Add(XElement.Parse($"<ErrorMessage><![CDATA[{ErrorMessage}]]></ErrorMessage>"));
+                valEl.Add(new XElement("ErrorMessage", new XCData(ErrorMessage)));
 
             el.Add(valEl);
         }

--- a/src/SharpFM.Model/Scripting/Values/Calculation.cs
+++ b/src/SharpFM.Model/Scripting/Values/Calculation.cs
@@ -16,7 +16,7 @@ public sealed record Calculation(string Text)
     /// common case in FileMaker script XML.
     /// </summary>
     public XElement ToXml(string elementName = "Calculation") =>
-        XElement.Parse($"<{elementName}><![CDATA[{Text}]]></{elementName}>");
+        new(elementName, new XCData(Text));
 
     /// <summary>
     /// Parse the text body of the element (CDATA is transparent to

--- a/src/SharpFM.Model/Scripting/XmlHelpers.cs
+++ b/src/SharpFM.Model/Scripting/XmlHelpers.cs
@@ -6,14 +6,6 @@ namespace SharpFM.Model.Scripting;
 
 public static class XmlHelpers
 {
-    public static string XmlEscape(string s)
-    {
-        return s.Replace("&", "&amp;")
-                .Replace("<", "&lt;")
-                .Replace(">", "&gt;")
-                .Replace("\"", "&quot;");
-    }
-
     public static string Unquote(string s)
     {
         if (s.Length >= 2 && s[0] == '"' && s[^1] == '"')

--- a/tests/SharpFM.Tests/ClipTypes/TableClipStrategyTests.cs
+++ b/tests/SharpFM.Tests/ClipTypes/TableClipStrategyTests.cs
@@ -100,6 +100,7 @@ public class TableClipStrategyTests
     [InlineData("My \"favorite\" stuff")]
     [InlineData("A & B")]
     [InlineData("<Angle>")]
+    [InlineData("O'Brien")]
     public void Table_DefaultXml_EscapesPunctuationInName(string clipName)
     {
         var seed = TableClipStrategy.Table.DefaultXml(clipName);

--- a/tests/SharpFM.Tests/Scripting/Values/CalculationTests.cs
+++ b/tests/SharpFM.Tests/Scripting/Values/CalculationTests.cs
@@ -55,4 +55,17 @@ public class CalculationTests
 
         Assert.Equal(expr, roundTripped.Value);
     }
+
+    [Theory]
+    [InlineData("a < b & c > d")]
+    [InlineData("Quote(\"hello\")")]
+    [InlineData("If ( name = \"O'Brien\" ; 1 ; 0 )")]
+    public void RoundTrip_PreservesXmlMetacharacters(string expr)
+    {
+        var emitted = new Calculation(expr).ToXml();
+        var serialized = emitted.ToString();
+        var reparsed = Calculation.FromXml(XElement.Parse(serialized));
+
+        Assert.Equal(expr, reparsed.Text);
+    }
 }


### PR DESCRIPTION
## Summary

Replaces nine string-interpolated XML construction sites with `XElement` / `XAttribute` / `XCData` API calls. The framework handles attribute escaping and CDATA wrapping; manual escaping is no longer needed.

## Why

`TableClipStrategy.DefaultXml` previously interpolated a clip name into an XML attribute via `$"<BaseTable name=\"{clipName}\">"`. A clip named `My "favorite" stuff` produced malformed XML; a recent fix patched the symptom by calling a hand-rolled `XmlHelpers.XmlEscape` before interpolation. Auditing for the same anti-pattern surfaced eight more sites: `Calculation.ToXml` and seven `XElement.Parse($"<X><![CDATA[{userText}]]></X>")` callsites in `FmField.ToXml`. All share the same root cause — building structured XML by string concatenation — and the same class of edge-case failure (e.g. `]]>` inside calc text would terminate the CDATA early and throw on parse).

## Scope

- `TableClipStrategy.DefaultXml` → `new XElement("BaseTable", new XAttribute("name", clipName))`
- `Calculation.ToXml` → `new XElement(name, new XCData(Text))`
- `FmField.ToXml` (×7: Calculation, ConstantData, MinimumValue, MaximumValue, StrictValidation, ErrorMessage, AutoEnter-Calculation) → same `XCData` pattern
- `XmlHelpers.XmlEscape` deleted (no callers remain)
- `IClipTypeStrategy.DefaultXml` doc-comment updated to point at `XElement` rather than at a manual-escape helper

`new XCData(text)` still can't legally hold the literal sequence `]]>` — that's an XML spec limitation, not an API one. The failure mode improves from "silent on-disk corruption" to "throw on save," which is acceptable; FileMaker's own calc grammar can't produce `]]>` either.

## Tests

All 1424 existing tests still pass. Added 3 new `Calculation.RoundTrip_PreservesXmlMetacharacters` cases covering `<`, `&`, `"`, `'` in calc text. Added one `O'Brien` Theory row to `Table_DefaultXml_EscapesPunctuationInName`.

## Follow-up

The display-text path uses a different escape contract (FileMaker's own quoting convention rather than XML escaping) and is tracked separately in #221 — script/layout/menu-set names containing `"` produce ambiguous display text. Round-trip *probably* still works via greedy regex but isn't covered by tests; lower priority than this fix.