### PR TITLE
ci: cap CI job runtime at 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   release:
     name: CI Build
+    # Hung runners (notably macOS) otherwise run to GitHub's 360-minute cap;
+    # builds finish in ~1-3 min, so 15 kills a hang fast with wide margin.
+    timeout-minutes: 15
     strategy:
       matrix:
         kind: ['linux', 'windows', 'macOS']


### PR DESCRIPTION
Adds `timeout-minutes: 15` to the CI matrix job so a hung runner is cancelled at 15 minutes instead of inheriting GitHub's default 360-minute cap.

CI run [`27243212776`](https://github.com/fuzzzerd/SharpFM/actions/runs/27243212776) had its macOS leg hang for the full 360 minutes (23:46 June 9 → 05:47 June 10) before cancellation, while linux and windows finished in ~1-2 min. macOS minutes bill at a 10x multiplier, so that single hang cost ~3,450 billed minutes. A scan of the last ~60 runs shows macOS normally completes in ~1 min, so 15 minutes leaves wide margin while capping the worst case.

The timeout is set at the job level, so it protects all three matrix legs (linux, windows, macOS).

Closes #232
